### PR TITLE
fix: fix Socket.io namespace error and Stripe booking confirm URL

### DIFF
--- a/web-client/src/components/layout/Header.tsx
+++ b/web-client/src/components/layout/Header.tsx
@@ -78,19 +78,21 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn = false, onLogout }) => {
         .catch(() => setUnreadNotificationsCount(0));
 
       notificationService.connect();
-      notificationService.onNewNotification(() => {
+      const handleNewNotification = () => {
         notificationService.getUnreadCount()
           .then(setUnreadNotificationsCount)
           .catch(() => {});
-      });
-    } else {
-      setUnreadNotificationsCount(0);
-      notificationService.disconnect();
+      };
+      notificationService.onNewNotification(handleNewNotification);
+
+      return () => {
+        notificationService.offNewNotification(handleNewNotification);
+        notificationService.disconnect();
+      };
     }
 
-    return () => {
-      notificationService.disconnect();
-    };
+    setUnreadNotificationsCount(0);
+    notificationService.disconnect();
   }, [isLoggedIn]);
 
   useEffect(() => {

--- a/web-client/src/pages/checkout/StripeCheckoutForm.tsx
+++ b/web-client/src/pages/checkout/StripeCheckoutForm.tsx
@@ -75,8 +75,8 @@ const StripeCheckoutForm = ({
 
         // Confirm the booking directly (bypass Kafka dependency)
         try {
-          const VOYAGE_API_URL = import.meta.env.VITE_VOYAGE_API_URL;
-          const confirmResponse = await fetch(`${VOYAGE_API_URL}/api/bookings/${bookingReference}/confirm`, {
+          const VOYAGE_API_URL = import.meta.env.VITE_VOYAGE_SERVICE_URL || 'http://localhost:3003/api';
+          const confirmResponse = await fetch(`${VOYAGE_API_URL}/v1/bookings/${bookingReference}/confirm`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/web-client/src/services/user/NotificationService.ts
+++ b/web-client/src/services/user/NotificationService.ts
@@ -108,7 +108,9 @@ class NotificationService {
 
     if (!token) return;
 
-    this.socket = io(USER_API_BASE_URL, {
+    // Connect to the base host (without /api path) since Socket.io uses the default namespace
+    const socketUrl = USER_API_BASE_URL?.replace(/\/api\/?$/, '') || 'http://localhost:3002';
+    this.socket = io(socketUrl, {
       auth: { token },
       transports: ['websocket'],
       reconnectionAttempts: 5,


### PR DESCRIPTION
- NotificationService: connect to base host without /api path to avoid Invalid namespace error, which prevented real-time notification counter
- Header: properly clean up notification listener with offNewNotification
- StripeCheckoutForm: use correct env var (VITE_VOYAGE_SERVICE_URL) and fix doubled /api in booking confirm URL