### PR TITLE
feat(DR-575): VR fallback with WebXR detection and 2D gallery mode

### DIFF
--- a/panorama/src/App.js
+++ b/panorama/src/App.js
@@ -7,7 +7,10 @@ import { VRButton, ARButton, XR, Controllers, Hands } from '@react-three/xr';
 import { OrbitControls, Text, Box } from '@react-three/drei';
 import * as THREE from 'three';
 import { useVRDeepLink } from './hooks/useVRDeepLink';
+import useWebXRDetection from './hooks/useWebXRDetection';
 import DeepLinkHandler from './components/DeepLinkHandler';
+import VRUnavailableScreen from './components/VRUnavailableScreen';
+import PanoramaGallery from './components/PanoramaGallery';
 import './App.css';
 
 // Services refactorisés (DR-250, DR-251, DR-252, DR-253, DR-410, DR-411)
@@ -578,9 +581,14 @@ function App() {
   const showControls = isDebugMode || !destination; // Masquer les contrôles en mode destination (sauf debug)
 
   const [diagnosticVisible, setDiagnosticVisible] = useState(isDebugMode);
+  const initialMode = searchParams.get('mode') || 'auto'; // ?mode=gallery|3d|auto
+  const [viewMode, setViewMode] = useState(initialMode);
 
   // DR-498 / DR-501 / DR-502: Deep Linking for QR Code Access
   const deepLinkState = useVRDeepLink();
+
+  // DR-575: WebXR detection for fallback
+  const { isXRSupported, isChecking, xrReason } = useWebXRDetection();
 
   // DR-574: PIN entry state - show PIN screen when no destination and no deep link
   const showPinEntry = !destination && !deepLinkState.isDeepLink;
@@ -591,6 +599,11 @@ function App() {
     if (autoVR) params.set('autoVR', 'true');
     window.location.search = params.toString();
   }, []);
+
+  // DR-575: View mode navigation callbacks
+  const handleSwitchToGallery = useCallback(() => setViewMode('gallery'), []);
+  const handleSwitchTo3D = useCallback(() => setViewMode('3d'), []);
+  const handleSwitchToVR = useCallback(() => setViewMode('auto'), []);
 
   const toggleDiagnostic = useCallback(() => {
     setDiagnosticVisible(prev => !prev);
@@ -612,6 +625,16 @@ function App() {
   // DR-574: Show PIN entry screen for VR headsets (no destination in URL)
   if (showPinEntry) {
     return <VRPinEntry onSuccess={handlePinSuccess} />;
+  }
+
+  // DR-575: Gallery mode
+  if (viewMode === 'gallery') {
+    return <PanoramaGallery onSwitchToVR={handleSwitchToVR} onSwitchTo3D={handleSwitchTo3D} destination={destination} />;
+  }
+
+  // DR-575: VR unavailable screen (only in auto mode, after detection completes)
+  if (viewMode === 'auto' && !isXRSupported && !isChecking) {
+    return <VRUnavailableScreen xrReason={xrReason} onSwitchToGallery={handleSwitchToGallery} onSwitchTo3D={handleSwitchTo3D} />;
   }
 
   return (
@@ -657,23 +680,42 @@ function App() {
           ⚠️ Placez votre image panoramique 360° nommée 'panorama-test.jpg' dans /public
         </p>
 
-        <VRButton
-          style={{
-            background: 'linear-gradient(45deg, #F97316, #DB2777)',
-            color: 'white',
-            border: 'none',
-            padding: '12px 24px',
-            borderRadius: '8px',
-            fontSize: '16px',
-            cursor: 'pointer',
-            margin: '10px',
-            boxShadow: '0 4px 15px rgba(249, 115, 22, 0.3)'
-          }}
-        />
+        {isXRSupported && (
+          <VRButton
+            style={{
+              background: 'linear-gradient(45deg, #F97316, #DB2777)',
+              color: 'white',
+              border: 'none',
+              padding: '12px 24px',
+              borderRadius: '8px',
+              fontSize: '16px',
+              cursor: 'pointer',
+              margin: '10px',
+              boxShadow: '0 4px 15px rgba(249, 115, 22, 0.3)'
+            }}
+          />
+        )}
 
-        <ARButton
+        {isXRSupported && (
+          <ARButton
+            style={{
+              background: 'linear-gradient(45deg, #3B82F6, #22C55E)',
+              color: 'white',
+              border: 'none',
+              padding: '12px 24px',
+              borderRadius: '8px',
+              fontSize: '16px',
+              cursor: 'pointer',
+              margin: '10px',
+              boxShadow: '0 4px 15px rgba(59, 130, 246, 0.3)'
+            }}
+          />
+        )}
+
+        <button
+          onClick={handleSwitchToGallery}
           style={{
-            background: 'linear-gradient(45deg, #3B82F6, #22C55E)',
+            background: 'linear-gradient(45deg, #8B5CF6, #6366F1)',
             color: 'white',
             border: 'none',
             padding: '12px 24px',
@@ -681,9 +723,11 @@ function App() {
             fontSize: '16px',
             cursor: 'pointer',
             margin: '10px',
-            boxShadow: '0 4px 15px rgba(59, 130, 246, 0.3)'
+            boxShadow: '0 4px 15px rgba(139, 92, 246, 0.3)'
           }}
-        />
+        >
+          🖼️ Mode Galerie 2D
+        </button>
       </div>
       )}
 

--- a/panorama/src/components/PanoramaGallery.js
+++ b/panorama/src/components/PanoramaGallery.js
@@ -1,0 +1,530 @@
+/**
+ * PanoramaGallery Component
+ * DR-575: Mode galerie 2D comme alternative au mode VR
+ *
+ * Pure HTML/CSS - aucune dépendance Three.js/Canvas (zéro overhead WebGL).
+ * Réutilise les données de environments.js.
+ * Charte graphique DreamScape : orange (#f97316) / pink (#ec4899) / blanc.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { listVREnvironments, VR_ENVIRONMENTS } from '../data/environments';
+
+export default function PanoramaGallery({ onSwitchToVR, onSwitchTo3D, destination }) {
+  // Si une destination est spécifiée (via ?destination=paris), on démarre directement dessus
+  const [selectedEnv, setSelectedEnv] = useState(destination || null);
+  const [currentSceneIndex, setCurrentSceneIndex] = useState(0);
+
+  // Si destination fixée, ne pas montrer la grille multi-destinations
+  const isLockedDestination = !!destination;
+
+  const environments = listVREnvironments();
+
+  // Get scenes for the selected environment
+  const scenes = selectedEnv ? (VR_ENVIRONMENTS[selectedEnv]?.scenes || []) : [];
+  const currentScene = scenes[currentSceneIndex] || null;
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!selectedEnv) return;
+
+    function handleKeyDown(e) {
+      if (e.key === 'ArrowLeft') {
+        setCurrentSceneIndex(prev => (prev > 0 ? prev - 1 : scenes.length - 1));
+      } else if (e.key === 'ArrowRight') {
+        setCurrentSceneIndex(prev => (prev < scenes.length - 1 ? prev + 1 : 0));
+      } else if (e.key === 'Escape' && !isLockedDestination) {
+        setSelectedEnv(null);
+        setCurrentSceneIndex(0);
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selectedEnv, scenes.length, isLockedDestination]);
+
+  const handleSelectEnv = useCallback((envId) => {
+    setSelectedEnv(envId);
+    setCurrentSceneIndex(0);
+  }, []);
+
+  const handleBackToGrid = useCallback(() => {
+    setSelectedEnv(null);
+    setCurrentSceneIndex(0);
+  }, []);
+
+  const handlePrevScene = useCallback(() => {
+    setCurrentSceneIndex(prev => (prev > 0 ? prev - 1 : scenes.length - 1));
+  }, [scenes.length]);
+
+  const handleNextScene = useCallback(() => {
+    setCurrentSceneIndex(prev => (prev < scenes.length - 1 ? prev + 1 : 0));
+  }, [scenes.length]);
+
+  return (
+    <div style={styles.container}>
+      {/* Header — style navbar DreamScape */}
+      <header style={styles.header}>
+        <div style={styles.headerLeft}>
+          <span style={styles.headerLogo}>🌍</span>
+          <span style={styles.headerTitle}>DreamScape</span>
+          <span style={styles.headerBadge}>Galerie 2D</span>
+        </div>
+        <div style={styles.headerButtons}>
+          <button onClick={onSwitchTo3D} style={styles.headerBtnSecondary} aria-label="Mode 3D interactif">
+            🔄 Mode 3D
+          </button>
+          <button onClick={onSwitchToVR} style={styles.headerBtnPrimary} aria-label="Retour en mode VR">
+            🥽 Mode VR
+          </button>
+        </div>
+      </header>
+
+      {/* Content */}
+      <div style={styles.main}>
+        {!selectedEnv ? (
+          /* === GRID VIEW === */
+          <div style={styles.gridContainer}>
+            <h1 style={styles.title}>Explorez nos destinations</h1>
+            <p style={styles.subtitle}>
+              Sélectionnez une destination pour parcourir ses panoramas
+            </p>
+
+            <div style={styles.grid}>
+              {environments.map((env) => {
+                const envData = VR_ENVIRONMENTS[env.id];
+                const firstScene = envData?.scenes?.[0];
+                const thumbUrl = firstScene?.thumbnailUrl;
+
+                return (
+                  <button
+                    key={env.id}
+                    onClick={() => handleSelectEnv(env.id)}
+                    style={styles.card}
+                    aria-label={`Explorer ${env.name}`}
+                  >
+                    <div style={styles.cardImageWrapper}>
+                      {thumbUrl ? (
+                        <img
+                          src={thumbUrl}
+                          alt={env.name}
+                          loading="lazy"
+                          style={styles.cardImage}
+                          onError={(e) => { e.target.style.display = 'none'; }}
+                        />
+                      ) : (
+                        <div style={styles.cardImageFallback}>
+                          <span style={{ fontSize: '48px' }}>{firstScene?.icon || '🌍'}</span>
+                        </div>
+                      )}
+                      <div style={styles.cardOverlay}>
+                        <span style={styles.cardBadge}>
+                          {env.sceneCount} panorama{env.sceneCount > 1 ? 's' : ''}
+                        </span>
+                      </div>
+                    </div>
+                    <div style={styles.cardBody}>
+                      <h3 style={styles.cardName}>{env.name}</h3>
+                      <p style={styles.cardDescription}>{env.description}</p>
+                      <span style={styles.cardCta}>Explorer →</span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          /* === PANORAMA VIEWER === */
+          <div style={styles.viewerContainer}>
+            {/* Back button */}
+            {!isLockedDestination && (
+              <button onClick={handleBackToGrid} style={styles.backButton} aria-label="Retour aux destinations">
+                ← Retour aux destinations
+              </button>
+            )}
+
+            {/* Scene image */}
+            <div style={styles.imageContainer}>
+              {currentScene?.panoramaUrl ? (
+                <img
+                  src={currentScene.panoramaUrl}
+                  alt={currentScene.name}
+                  style={styles.panoramaImage}
+                  onError={(e) => { e.target.style.display = 'none'; }}
+                />
+              ) : (
+                <div style={styles.imagePlaceholder}>
+                  <span style={{ fontSize: '56px' }}>{currentScene?.icon || '🌍'}</span>
+                  <p style={styles.placeholderText}>Image non disponible</p>
+                </div>
+              )}
+
+              {/* Overlay bar */}
+              <div style={styles.overlayBar}>
+                <button
+                  onClick={handlePrevScene}
+                  style={styles.navButton}
+                  aria-label="Scène précédente"
+                  disabled={scenes.length <= 1}
+                >
+                  ◀
+                </button>
+
+                <div style={styles.sceneInfo}>
+                  <span style={styles.sceneName}>
+                    {currentScene?.icon} {currentScene?.name}
+                  </span>
+                  <span style={styles.sceneDescription}>{currentScene?.description}</span>
+                  <span style={styles.sceneCounter}>
+                    {currentSceneIndex + 1} / {scenes.length}
+                  </span>
+                </div>
+
+                <button
+                  onClick={handleNextScene}
+                  style={styles.navButton}
+                  aria-label="Scène suivante"
+                  disabled={scenes.length <= 1}
+                >
+                  ▶
+                </button>
+              </div>
+            </div>
+
+            {/* Scene thumbnails strip */}
+            {scenes.length > 1 && (
+              <div style={styles.thumbStrip}>
+                {scenes.map((scene, idx) => (
+                  <button
+                    key={scene.id}
+                    onClick={() => setCurrentSceneIndex(idx)}
+                    style={{
+                      ...styles.thumbItem,
+                      ...(idx === currentSceneIndex ? styles.thumbItemActive : {}),
+                    }}
+                    aria-label={scene.name}
+                  >
+                    <span style={styles.thumbIcon}>{scene.icon}</span>
+                    <span style={styles.thumbName}>{scene.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Styles — Charte DreamScape (orange/pink/blanc) ---
+
+const styles = {
+  // === Layout ===
+  container: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 9999,
+    display: 'flex',
+    flexDirection: 'column',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    background: '#f9fafb',
+    overflow: 'auto',
+  },
+
+  // === Header — style navbar DreamScape (frosted white) ===
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '12px 24px',
+    background: 'rgba(255, 255, 255, 0.8)',
+    backdropFilter: 'blur(12px)',
+    WebkitBackdropFilter: 'blur(12px)',
+    borderBottom: '1px solid #f3f4f6',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.05)',
+    flexShrink: 0,
+  },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+  },
+  headerLogo: {
+    fontSize: '28px',
+  },
+  headerTitle: {
+    fontSize: '20px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+  },
+  headerBadge: {
+    fontSize: '12px',
+    fontWeight: 'bold',
+    color: '#f97316',
+    background: '#fff7ed',
+    padding: '2px 10px',
+    borderRadius: '50px',
+  },
+  headerButtons: {
+    display: 'flex',
+    gap: '8px',
+  },
+  headerBtnSecondary: {
+    padding: '8px 16px',
+    fontSize: '14px',
+    fontWeight: '500',
+    color: '#374151',
+    background: '#ffffff',
+    border: '1px solid #e5e7eb',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+  },
+  headerBtnPrimary: {
+    padding: '8px 16px',
+    fontSize: '14px',
+    fontWeight: '600',
+    color: '#ffffff',
+    background: 'linear-gradient(135deg, #f97316 0%, #ec4899 100%)',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    boxShadow: '0 2px 8px rgba(249, 115, 22, 0.3)',
+    transition: 'all 0.2s',
+  },
+
+  // === Main Content ===
+  main: {
+    flex: 1,
+    padding: '32px 24px',
+    overflow: 'auto',
+  },
+
+  // === Grid View ===
+  gridContainer: {
+    maxWidth: '960px',
+    margin: '0 auto',
+  },
+  title: {
+    fontSize: '32px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+    margin: '0 0 8px 0',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: '16px',
+    color: '#6b7280',
+    margin: '0 0 32px 0',
+    textAlign: 'center',
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    gap: '24px',
+  },
+  card: {
+    background: '#ffffff',
+    borderRadius: '12px',
+    overflow: 'hidden',
+    cursor: 'pointer',
+    border: 'none',
+    padding: 0,
+    width: '100%',
+    textAlign: 'left',
+    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+    transition: 'all 0.3s',
+  },
+  cardImageWrapper: {
+    position: 'relative',
+    width: '100%',
+    height: '180px',
+    overflow: 'hidden',
+  },
+  cardImage: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    transition: 'transform 0.5s',
+  },
+  cardImageFallback: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'linear-gradient(135deg, #fff7ed 0%, #fce7f3 100%)',
+  },
+  cardOverlay: {
+    position: 'absolute',
+    top: '12px',
+    right: '12px',
+  },
+  cardBadge: {
+    display: 'inline-block',
+    padding: '4px 12px',
+    fontSize: '12px',
+    fontWeight: 'bold',
+    color: '#ffffff',
+    background: 'linear-gradient(135deg, #f97316 0%, #ec4899 100%)',
+    borderRadius: '50px',
+    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+  },
+  cardBody: {
+    padding: '16px',
+  },
+  cardName: {
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+    margin: '0 0 4px 0',
+  },
+  cardDescription: {
+    fontSize: '14px',
+    color: '#6b7280',
+    margin: '0 0 12px 0',
+    lineHeight: '1.4',
+  },
+  cardCta: {
+    fontSize: '14px',
+    fontWeight: '600',
+    color: '#f97316',
+  },
+
+  // === Viewer ===
+  viewerContainer: {
+    maxWidth: '1000px',
+    margin: '0 auto',
+    width: '100%',
+  },
+  backButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '8px 16px',
+    fontSize: '14px',
+    fontWeight: '500',
+    color: '#374151',
+    background: '#ffffff',
+    border: '1px solid #e5e7eb',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    marginBottom: '16px',
+  },
+  imageContainer: {
+    position: 'relative',
+    borderRadius: '12px',
+    overflow: 'hidden',
+    background: '#1f2937',
+    boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.2)',
+  },
+  panoramaImage: {
+    width: '100%',
+    height: '500px',
+    objectFit: 'cover',
+    display: 'block',
+  },
+  imagePlaceholder: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '500px',
+    background: 'linear-gradient(135deg, #fff7ed 0%, #fce7f3 100%)',
+  },
+  placeholderText: {
+    color: '#6b7280',
+    marginTop: '12px',
+    fontSize: '15px',
+  },
+  overlayBar: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: 'flex',
+    alignItems: 'center',
+    padding: '20px 24px',
+    background: 'linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0) 100%)',
+    gap: '16px',
+  },
+  navButton: {
+    width: '44px',
+    height: '44px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#ffffff',
+    background: 'rgba(255, 255, 255, 0.2)',
+    backdropFilter: 'blur(8px)',
+    WebkitBackdropFilter: 'blur(8px)',
+    border: 'none',
+    borderRadius: '50%',
+    cursor: 'pointer',
+    flexShrink: 0,
+    transition: 'all 0.2s',
+  },
+  sceneInfo: {
+    flex: 1,
+    textAlign: 'center',
+  },
+  sceneName: {
+    display: 'block',
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#ffffff',
+    marginBottom: '2px',
+  },
+  sceneDescription: {
+    display: 'block',
+    fontSize: '14px',
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginBottom: '2px',
+  },
+  sceneCounter: {
+    display: 'block',
+    fontSize: '12px',
+    fontWeight: 'bold',
+    color: '#fdba74',
+  },
+
+  // === Thumbnails strip ===
+  thumbStrip: {
+    display: 'flex',
+    gap: '8px',
+    marginTop: '16px',
+    overflowX: 'auto',
+    padding: '4px 0',
+  },
+  thumbItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '10px 16px',
+    background: '#ffffff',
+    borderWidth: '2px',
+    borderStyle: 'solid',
+    borderColor: '#e5e7eb',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    flexShrink: 0,
+    transition: 'all 0.2s',
+  },
+  thumbItemActive: {
+    borderColor: '#f97316',
+    background: '#fff7ed',
+  },
+  thumbIcon: {
+    fontSize: '18px',
+  },
+  thumbName: {
+    fontSize: '13px',
+    fontWeight: '600',
+    color: '#374151',
+    whiteSpace: 'nowrap',
+  },
+};

--- a/panorama/src/components/VRUnavailableScreen.js
+++ b/panorama/src/components/VRUnavailableScreen.js
@@ -1,0 +1,236 @@
+/**
+ * VRUnavailableScreen Component
+ * DR-575: Écran de fallback quand WebXR n'est pas disponible
+ *
+ * Affiche un message contextuel selon la raison et propose
+ * des alternatives (galerie 2D ou mode 3D interactif).
+ * Charte graphique DreamScape : orange (#f97316) / pink (#ec4899) / blanc.
+ */
+
+import React from 'react';
+
+const REASON_CONFIG = {
+  'no-webxr-api': {
+    icon: '🌐',
+    title: 'Navigateur non compatible WebXR',
+    message: 'Votre navigateur ne supporte pas la réalité virtuelle WebXR.',
+    suggestion: 'Essayez Google Chrome, Microsoft Edge ou Meta Quest Browser pour une expérience VR complète.',
+  },
+  'no-headset': {
+    icon: '🥽',
+    title: 'Casque VR non détecté',
+    message: 'Aucun casque de réalité virtuelle n\'a été détecté sur cet appareil.',
+    suggestion: 'Connectez votre casque VR (Meta Quest, HTC Vive, etc.) et rafraîchissez la page.',
+  },
+  'error': {
+    icon: '⚠️',
+    title: 'Erreur de détection VR',
+    message: 'Une erreur est survenue lors de la vérification du support WebXR.',
+    suggestion: 'Vérifiez que votre navigateur est à jour et réessayez.',
+  },
+};
+
+export default function VRUnavailableScreen({ xrReason, onSwitchToGallery, onSwitchTo3D }) {
+  const config = REASON_CONFIG[xrReason] || REASON_CONFIG['error'];
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.content}>
+        {/* Logo */}
+        <div style={styles.logo}>
+          <span style={styles.logoIcon}>🌍</span>
+          <span style={styles.logoText}>DreamScape</span>
+        </div>
+
+        {/* Status card */}
+        <div style={styles.statusCard}>
+          <div style={styles.statusIcon}>{config.icon}</div>
+          <h1 style={styles.title}>{config.title}</h1>
+          <p style={styles.message}>{config.message}</p>
+          <p style={styles.suggestion}>{config.suggestion}</p>
+        </div>
+
+        {/* CTA buttons */}
+        <div style={styles.buttonContainer}>
+          <button
+            onClick={onSwitchToGallery}
+            style={styles.primaryButton}
+            aria-label="Explorer en mode Galerie 2D"
+          >
+            <span style={styles.buttonIcon}>🖼️</span>
+            <span>Explorer en mode Galerie 2D</span>
+          </button>
+
+          <button
+            onClick={onSwitchTo3D}
+            style={styles.secondaryButton}
+            aria-label="Voir en mode 3D interactif"
+          >
+            <span style={styles.buttonIcon}>🔄</span>
+            <span>Voir en mode 3D interactif</span>
+          </button>
+        </div>
+
+        {/* Help section */}
+        <div style={styles.helpSection}>
+          <p style={styles.helpTitle}>Comment activer la VR ?</p>
+          <div style={styles.helpStep}>
+            <span style={styles.stepNumber}>1</span>
+            <span>Utilisez un navigateur compatible (Chrome, Edge, Firefox)</span>
+          </div>
+          <div style={styles.helpStep}>
+            <span style={styles.stepNumber}>2</span>
+            <span>Connectez et allumez votre casque VR</span>
+          </div>
+          <div style={styles.helpStep}>
+            <span style={styles.stepNumber}>3</span>
+            <span>Rafraîchissez cette page pour relancer la détection</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Styles — Charte DreamScape (orange/pink/blanc) ---
+
+const styles = {
+  container: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 9999,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    background: '#f9fafb',
+    overflow: 'auto',
+  },
+  content: {
+    textAlign: 'center',
+    padding: '40px 32px',
+    maxWidth: '520px',
+    width: '100%',
+  },
+  logo: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '10px',
+    marginBottom: '32px',
+  },
+  logoIcon: {
+    fontSize: '36px',
+  },
+  logoText: {
+    fontSize: '24px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+  },
+  statusCard: {
+    background: '#ffffff',
+    borderRadius: '12px',
+    padding: '32px 24px',
+    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+    marginBottom: '24px',
+  },
+  statusIcon: {
+    fontSize: '56px',
+    marginBottom: '16px',
+  },
+  title: {
+    fontSize: '22px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+    margin: '0 0 8px 0',
+  },
+  message: {
+    fontSize: '15px',
+    color: '#6b7280',
+    margin: '0 0 8px 0',
+    lineHeight: '1.5',
+  },
+  suggestion: {
+    fontSize: '14px',
+    color: '#f97316',
+    margin: '0',
+    lineHeight: '1.5',
+    fontWeight: '500',
+  },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    marginBottom: '24px',
+  },
+  primaryButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '12px',
+    width: '100%',
+    padding: '16px 24px',
+    fontSize: '16px',
+    fontWeight: 'bold',
+    color: '#ffffff',
+    background: 'linear-gradient(135deg, #f97316 0%, #ec4899 100%)',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    boxShadow: '0 4px 15px rgba(249, 115, 22, 0.3)',
+    transition: 'all 0.2s',
+  },
+  secondaryButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '12px',
+    width: '100%',
+    padding: '14px 24px',
+    fontSize: '15px',
+    fontWeight: '500',
+    color: '#374151',
+    background: '#ffffff',
+    border: '1px solid #e5e7eb',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+  },
+  buttonIcon: {
+    fontSize: '22px',
+  },
+  helpSection: {
+    textAlign: 'left',
+    background: '#ffffff',
+    borderRadius: '12px',
+    padding: '20px 24px',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
+  },
+  helpTitle: {
+    fontSize: '15px',
+    fontWeight: 'bold',
+    color: '#1f2937',
+    margin: '0 0 14px 0',
+  },
+  helpStep: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '12px',
+    marginBottom: '10px',
+    fontSize: '14px',
+    color: '#6b7280',
+    lineHeight: '1.4',
+  },
+  stepNumber: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: '26px',
+    height: '26px',
+    borderRadius: '50%',
+    background: '#fff7ed',
+    color: '#f97316',
+    fontSize: '13px',
+    fontWeight: 'bold',
+  },
+};

--- a/panorama/src/hooks/useWebXRDetection.js
+++ b/panorama/src/hooks/useWebXRDetection.js
@@ -1,0 +1,59 @@
+/**
+ * useWebXRDetection Hook
+ * DR-575: Détection WebXR et fallback gracieux
+ *
+ * Vérifie si le navigateur supporte WebXR et si un casque VR est disponible.
+ * Retourne l'état de support avec une raison explicite.
+ */
+
+import { useState, useEffect } from 'react';
+
+/**
+ * @returns {{ isXRSupported: boolean, isChecking: boolean, xrReason: string }}
+ * - xrReason: 'supported' | 'no-webxr-api' | 'no-headset' | 'error'
+ */
+export default function useWebXRDetection() {
+  const [isXRSupported, setIsXRSupported] = useState(false);
+  const [isChecking, setIsChecking] = useState(true);
+  const [xrReason, setXrReason] = useState('supported');
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function checkXR() {
+      // No WebXR API at all
+      if (!navigator.xr) {
+        if (mounted) {
+          setIsXRSupported(false);
+          setXrReason('no-webxr-api');
+          setIsChecking(false);
+        }
+        return;
+      }
+
+      try {
+        const supported = await navigator.xr.isSessionSupported('immersive-vr');
+        if (mounted) {
+          setIsXRSupported(supported);
+          setXrReason(supported ? 'supported' : 'no-headset');
+          setIsChecking(false);
+        }
+      } catch (err) {
+        console.warn('WebXR detection error:', err);
+        if (mounted) {
+          setIsXRSupported(false);
+          setXrReason('error');
+          setIsChecking(false);
+        }
+      }
+    }
+
+    checkXR();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { isXRSupported, isChecking, xrReason };
+}

--- a/web-client/src/pages/destination/[id].tsx
+++ b/web-client/src/pages/destination/[id].tsx
@@ -1,9 +1,20 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Star, MapPin, Calendar, Heart, Share2, Clock, Glasses } from 'lucide-react';
+import { ArrowLeft, Star, MapPin, Calendar, Heart, Share2, Clock, Glasses, Image } from 'lucide-react';
 import voyageService from '@/services/voyage/VoyageService';
 import imageService from '@/services/utility/imageService';
 import QRCodeDisplay from '../../components/vr/QRCodeDisplay';
+
+const PANORAMA_PORT = import.meta.env.VITE_PANORAMA_PORT || '3006';
+
+// Mapping destination IDs / airport codes → panorama environment IDs
+const GALLERY_ENVIRONMENT_MAP: Record<string, string> = {
+  'paris': 'paris',
+  'PAR': 'paris',
+  'CDG': 'paris',
+  'barcelona': 'barcelona',
+  'BCN': 'barcelona',
+};
 
 interface Destination {
   id: string;
@@ -317,6 +328,17 @@ export default function DestinationPage() {
               expirationMinutes={10}
             />
           </div>
+          {GALLERY_ENVIRONMENT_MAP[id?.toUpperCase() || ''] || GALLERY_ENVIRONMENT_MAP[id || ''] ? (
+            <a
+              href={`${window.location.protocol}//${window.location.hostname}:${PANORAMA_PORT}?destination=${GALLERY_ENVIRONMENT_MAP[id?.toUpperCase() || ''] || GALLERY_ENVIRONMENT_MAP[id || '']}&mode=gallery`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 bg-white bg-opacity-20 rounded-lg backdrop-blur-sm hover:bg-opacity-30 transition-all flex items-center gap-2 text-white text-sm"
+            >
+              <Image className="w-5 h-5" />
+              <span>Explorer en 2D</span>
+            </a>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `useWebXRDetection` hook for WebXR API detection (`supported` | `no-webxr-api` | `no-headset` | `error`)
- Add `VRUnavailableScreen` component with contextual error messages and CTA buttons (gallery 2D / mode 3D)
- Add `PanoramaGallery` component (pure HTML/CSS, zero WebGL overhead) with grid view, panorama viewer, keyboard navigation, and thumbnail strip
- Modify `App.js` with conditional view routing (`auto` | `gallery` | `3d`) and conditional VRButton/ARButton rendering
- Add "Explorer en 2D" button on destination page (`/destination/PAR`) linking to panorama gallery
- Support locked destination mode via `?destination=` URL param (scoped to single destination)
- DreamScape platform design system (orange/pink/white theme)

## Test plan
- [ ] 30 unit tests passing in `dreamscape-tests` (hook, VRUnavailableScreen, PanoramaGallery)
- [ ] Open panorama on port 3006/3008 without VR headset → VRUnavailableScreen displayed
- [ ] Click "Galerie 2D" → grid of destinations with navigation
- [ ] Open `?destination=paris&mode=gallery` → locked to Paris scenes only
- [ ] Click "Mode 3D" → existing Canvas with OrbitControls
- [ ] VRButton only visible when WebXR is supported
- [ ] "Explorer en 2D" button visible on `/destination/PAR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)