### PR TITLE
fix(vr): correct misleading port comment in VRPinAccess

### DIFF
--- a/web-client/src/components/vr/VRPinAccess.tsx
+++ b/web-client/src/components/vr/VRPinAccess.tsx
@@ -35,7 +35,7 @@ export default function VRPinAccess({
   const [expirationTime, setExpirationTime] = useState<number | null>(null);
 
   // Build the panorama URL to display to the user
-  // In dev: PANORAMA_BASE_URL is absolute (http://localhost:3008) → strip protocol
+  // In dev: PANORAMA_BASE_URL is absolute (http://<PC_IP>:3006) → strip protocol
   // In prod: PANORAMA_BASE_URL is relative (/panorama) → prepend host
   const panoramaUrl = PANORAMA_BASE_URL.startsWith('http')
     ? PANORAMA_BASE_URL.replace(/^https?:\/\//, '')


### PR DESCRIPTION
## Summary
- Fixed misleading comment in `VRPinAccess.tsx` that referenced `localhost:3008` — the panorama service actually runs on port **3006**
- Also fixed `panorama/.env` locally (gateway URL port 3000 → 4000 for dev, gitignored)

## Context
When testing VR with Meta Link, the incorrect port reference caused confusion leading to `chrome-error://chromewebdata/` cross-origin errors in the Quest browser.

## Test plan
- [ ] Verify VR PIN access flow works with correct port (3006)
- [ ] Test from Meta Quest browser at `http://<PC_IP>:3006`

🤖 Generated with [Claude Code](https://claude.com/claude-code)