### PR TITLE
feat(US-CORE-003): Password reset UI — forgot-password & reset-password pages

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -59,6 +59,10 @@ import PrivacyPolicyPage from '@/pages/legal/PrivacyPolicy';
 import HelpPage from '@/pages/help';
 import FaqPage from '@/pages/faq';
 
+// Password Reset Pages
+import ForgotPasswordPage from '@/pages/forgot-password';
+import ResetPasswordPage from '@/pages/reset-password';
+
 // GDPR
 import CookieConsent from '@/components/gdpr/CookieConsent';
 
@@ -173,6 +177,8 @@ function App() {
             <Route path="/support" element={<SupportPage />} />
             <Route path="/help" element={<HelpPage />} />
             <Route path="/faq" element={<FaqPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
 
             {/* Legal Routes */}
             <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />

--- a/web-client/src/components/auth/LoginForm.tsx
+++ b/web-client/src/components/auth/LoginForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -114,12 +115,12 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSubmit, onSwitchToSignup, isLoa
 
           {/* Forgot Password */}
           <div className="flex items-center justify-end">
-            <button
-              type="button"
-              className="text-xs md:text-sm text-orange-500 hover:text-orange-600 min-h-[44px] md:min-h-0 py-2 md:py-0"
+            <Link
+              to="/forgot-password"
+              className="text-xs md:text-sm text-orange-500 hover:text-orange-600 py-2 md:py-0"
             >
               {t('login.forgotPassword')}
-            </button>
+            </Link>
           </div>
 
           {/* Submit Button */}

--- a/web-client/src/pages/forgot-password.tsx
+++ b/web-client/src/pages/forgot-password.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Mail, ArrowLeft, CheckCircle } from 'lucide-react';
+import { authApiService } from '@/services/auth/AuthService';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+    try {
+      await authApiService.forgotPassword(email);
+      setSent(true);
+    } catch (err: any) {
+      setError(err?.response?.data?.message || 'Une erreur est survenue. Veuillez réessayer.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-pink-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-xl p-8">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-orange-100 rounded-full mb-4">
+              <Mail className="w-8 h-8 text-orange-500" />
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900">Mot de passe oublié</h1>
+            <p className="text-gray-500 mt-2 text-sm">
+              Entrez votre adresse email et nous vous enverrons un lien pour réinitialiser votre mot de passe.
+            </p>
+          </div>
+
+          {sent ? (
+            <div className="text-center space-y-4">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 rounded-full">
+                <CheckCircle className="w-8 h-8 text-green-500" />
+              </div>
+              <p className="text-gray-700 font-medium">Email envoyé !</p>
+              <p className="text-gray-500 text-sm">
+                Si un compte existe avec l'adresse <strong>{email}</strong>, vous recevrez un lien de réinitialisation dans quelques minutes.
+              </p>
+              <p className="text-gray-400 text-xs">
+                Vérifiez également votre dossier spam.
+              </p>
+              <Link
+                to="/auth"
+                className="inline-flex items-center gap-2 text-orange-500 hover:text-orange-700 text-sm font-medium mt-4"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Retour à la connexion
+              </Link>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div>
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                  Adresse email
+                </label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    placeholder="vous@exemple.com"
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent text-sm"
+                  />
+                </div>
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-4 py-2">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={isLoading || !email}
+                className="w-full py-3 bg-gradient-to-r from-orange-500 to-pink-500 text-white rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50 font-medium text-sm"
+              >
+                {isLoading ? (
+                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto" />
+                ) : (
+                  'Envoyer le lien de réinitialisation'
+                )}
+              </button>
+
+              <Link
+                to="/auth"
+                className="flex items-center justify-center gap-2 text-gray-500 hover:text-gray-700 text-sm"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Retour à la connexion
+              </Link>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/pages/reset-password.tsx
+++ b/web-client/src/pages/reset-password.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Lock, Eye, EyeOff, CheckCircle, ArrowLeft } from 'lucide-react';
+import { authApiService } from '@/services/auth/AuthService';
+
+const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/;
+
+function getPasswordStrengthErrors(password: string): string[] {
+  const errors: string[] = [];
+  if (password.length < 8) errors.push('Au moins 8 caractères');
+  if (!/[a-z]/.test(password)) errors.push('Une lettre minuscule');
+  if (!/[A-Z]/.test(password)) errors.push('Une lettre majuscule');
+  if (!/\d/.test(password)) errors.push('Un chiffre');
+  if (!/[@$!%*?&]/.test(password)) errors.push('Un caractère spécial (@$!%*?&)');
+  return errors;
+}
+
+export default function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      navigate('/forgot-password', { replace: true });
+    }
+  }, [token, navigate]);
+
+  const strengthErrors = getPasswordStrengthErrors(newPassword);
+  const isValid =
+    strengthErrors.length === 0 &&
+    newPassword === confirmPassword &&
+    newPassword.length > 0;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValid || !token) return;
+    setError('');
+    setIsLoading(true);
+    try {
+      await authApiService.resetPassword(token, newPassword);
+      setSuccess(true);
+      setTimeout(() => navigate('/auth', { replace: true }), 3000);
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || '';
+      if (msg === 'Invalid or expired token') {
+        setError('Ce lien de réinitialisation est invalide ou a expiré. Veuillez faire une nouvelle demande.');
+      } else {
+        setError(msg || 'Une erreur est survenue. Veuillez réessayer.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!token) return null;
+
+  if (success) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-pink-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-md">
+          <div className="bg-white rounded-2xl shadow-xl p-8 text-center space-y-4">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 rounded-full">
+              <CheckCircle className="w-8 h-8 text-green-500" />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900">Mot de passe réinitialisé !</h2>
+            <p className="text-gray-500 text-sm">
+              Votre mot de passe a été mis à jour avec succès. Vous allez être redirigé vers la page de connexion.
+            </p>
+            <Link to="/auth" className="inline-flex items-center gap-2 text-orange-500 hover:text-orange-700 text-sm font-medium">
+              <ArrowLeft className="w-4 h-4" />
+              Se connecter maintenant
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-pink-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-xl p-8">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-orange-100 rounded-full mb-4">
+              <Lock className="w-8 h-8 text-orange-500" />
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900">Nouveau mot de passe</h1>
+            <p className="text-gray-500 mt-2 text-sm">
+              Choisissez un nouveau mot de passe sécurisé pour votre compte.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            {/* New password */}
+            <div>
+              <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                Nouveau mot de passe
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <input
+                  id="newPassword"
+                  type={showPassword ? 'text' : 'password'}
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  placeholder="Nouveau mot de passe"
+                  className="w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              </div>
+              {newPassword && strengthErrors.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {strengthErrors.map((err) => (
+                    <li key={err} className="text-xs text-red-500 flex items-center gap-1">
+                      <span className="w-1 h-1 rounded-full bg-red-500 inline-block" />
+                      {err}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {/* Confirm password */}
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                Confirmer le mot de passe
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <input
+                  id="confirmPassword"
+                  type={showConfirm ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  placeholder="Confirmer le mot de passe"
+                  className="w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm(!showConfirm)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                >
+                  {showConfirm ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              </div>
+              {confirmPassword && newPassword !== confirmPassword && (
+                <p className="mt-1 text-xs text-red-500">Les mots de passe ne correspondent pas</p>
+              )}
+            </div>
+
+            {error && (
+              <div className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-4 py-3 space-y-2">
+                <p>{error}</p>
+                {error.includes('invalide ou a expiré') && (
+                  <Link to="/forgot-password" className="text-orange-500 hover:text-orange-700 underline text-xs">
+                    Faire une nouvelle demande
+                  </Link>
+                )}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={!isValid || isLoading}
+              className="w-full py-3 bg-gradient-to-r from-orange-500 to-pink-500 text-white rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50 font-medium text-sm"
+            >
+              {isLoading ? (
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto" />
+              ) : (
+                'Réinitialiser mon mot de passe'
+              )}
+            </button>
+
+            <Link
+              to="/forgot-password"
+              className="flex items-center justify-center gap-2 text-gray-500 hover:text-gray-700 text-sm"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Retour
+            </Link>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/services/auth/AuthService.ts
+++ b/web-client/src/services/auth/AuthService.ts
@@ -78,6 +78,16 @@ class AuthApiService {
     return response.data;
   }
 
+  async forgotPassword(email: string): Promise<any> {
+    const response = await this.api.post('/auth/forgot-password', { email });
+    return response.data;
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<any> {
+    const response = await this.api.put('/auth/reset-password', { token, newPassword });
+    return response.data;
+  }
+
   async getUserSettings(token: string): Promise<any> {
     try {
       // Fetch from user service


### PR DESCRIPTION
## Summary
- Lien "Mot de passe oublié ?" activé dans `LoginForm.tsx` (était un bouton inactif) → `/forgot-password`
- `forgotPassword()` et `resetPassword()` ajoutés à `AuthApiService`
- Page `/forgot-password` : formulaire email + confirmation visuelle après envoi
- Page `/reset-password` : token depuis URL, validation force mot de passe temps réel, redirect auto vers `/auth` après succès, gestion explicite token expiré

## Test plan
- [ ] Clic "Mot de passe oublié ?" → redirige vers `/forgot-password`
- [ ] Soumission email → message de confirmation affiché
- [ ] `/reset-password` sans token → redirect vers `/forgot-password`
- [ ] Validation temps réel (règles affichées sous le champ)
- [ ] Succès → confirmation + redirect `/auth` après 3s
- [ ] Token invalide → message d'erreur avec lien pour refaire une demande
