### PR TITLE
fix(env): remove duplicate VITE_GATEWAY_URL causing mixed content (DR-574)

### DIFF
--- a/web-client/.env.staging
+++ b/web-client/.env.staging
@@ -9,12 +9,6 @@ VITE_API_BASE_URL=https://79.72.27.180.nip.io/api
 # Gateway URL for VR PIN generation (VRPinAccess component)
 VITE_GATEWAY_URL=https://79.72.27.180.nip.io
 
-# Gateway URL for VR PIN generation (VRPinAccess component)
-VITE_GATEWAY_URL=http://79.72.27.180
-
-# Gateway URL for VR PIN generation (VRPinAccess component)
-VITE_GATEWAY_URL=http://79.72.27.180
-
 # Auth Service (via Gateway)
 VITE_AUTH_SERVICE_URL=https://79.72.27.180.nip.io/api
 


### PR DESCRIPTION
## Summary
- Remove duplicate `VITE_GATEWAY_URL` entries in `.env.staging`
- The last two (http://) were overriding the first (https://), causing mixed content errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)