### PR TITLE
fix(panorama): always show Enter VR button when autoVR=true (DR-574)

### DIFF
--- a/panorama/src/App.js
+++ b/panorama/src/App.js
@@ -633,7 +633,10 @@ function App() {
   }
 
   // DR-575: VR unavailable — auto-switch to 3D panorama when destination is loaded (PC browser or no headset)
-  if (viewMode === 'auto' && !isXRSupported && !isChecking) {
+  // Skip fallback when autoVR=true (deep link from VR headset) — always show VR UI with Enter VR button
+  const urlParams = new URLSearchParams(window.location.search);
+  const forceVR = urlParams.get('autoVR') === 'true';
+  if (viewMode === 'auto' && !isXRSupported && !isChecking && !forceVR) {
     if (destination) {
       setTimeout(() => setViewMode('3d'), 0);
       return null;
@@ -684,7 +687,7 @@ function App() {
           ⚠️ Placez votre image panoramique 360° nommée 'panorama-test.jpg' dans /public
         </p>
 
-        {isXRSupported && (
+        {(isXRSupported || forceVR) && (
           <VRButton
             style={{
               background: 'linear-gradient(45deg, #F97316, #DB2777)',
@@ -700,7 +703,7 @@ function App() {
           />
         )}
 
-        {isXRSupported && (
+        {(isXRSupported || forceVR) && (
           <ARButton
             style={{
               background: 'linear-gradient(45deg, #3B82F6, #22C55E)',


### PR DESCRIPTION
## Summary
- Skip WebXR detection fallback when `?autoVR=true` is in the URL
- Always show "Enter VR" and "Enter AR" buttons for VR headset deep links
- PC users without `autoVR=true` still get the 3D fallback as before

## Test plan
- [ ] On VR headset: `/panorama/?destination=par&autoVR=true` shows Enter VR button
- [ ] On PC: `/panorama/?destination=par` still shows 3D panorama (no VR button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)