### PR TITLE
fix(panorama): floating VR button in destination mode (DR-574)

### DIFF
--- a/panorama/src/App.js
+++ b/panorama/src/App.js
@@ -738,6 +738,47 @@ function App() {
       </div>
       )}
 
+      {/* DR-574: Floating VR/AR buttons visible in destination mode (when controls are hidden) */}
+      {!showControls && (isXRSupported || forceVR) && (
+        <div style={{
+          position: 'fixed',
+          bottom: '24px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 9999,
+          display: 'flex',
+          gap: '12px',
+          pointerEvents: 'auto'
+        }}>
+          <VRButton
+            style={{
+              background: 'linear-gradient(45deg, #F97316, #DB2777)',
+              color: 'white',
+              border: 'none',
+              padding: '16px 32px',
+              borderRadius: '12px',
+              fontSize: '18px',
+              fontWeight: 'bold',
+              cursor: 'pointer',
+              boxShadow: '0 8px 24px rgba(249, 115, 22, 0.5)'
+            }}
+          />
+          <ARButton
+            style={{
+              background: 'linear-gradient(45deg, #3B82F6, #22C55E)',
+              color: 'white',
+              border: 'none',
+              padding: '16px 32px',
+              borderRadius: '12px',
+              fontSize: '18px',
+              fontWeight: 'bold',
+              cursor: 'pointer',
+              boxShadow: '0 8px 24px rgba(59, 130, 246, 0.5)'
+            }}
+          />
+        </div>
+      )}
+
       <Canvas
         style={{
           height: '80vh',


### PR DESCRIPTION
## Summary
- VRButton was nested inside `{showControls && (...)}` panel
- `showControls = isDebugMode || !destination` → hidden when destination is set (production PIN flow)
- Add floating overlay VR/AR buttons that render independently when `isXRSupported || forceVR`

## Test plan
- [ ] Quest 3 headset: Enter VR button visible on `/panorama/?destination=par&autoVR=true`
- [ ] Clicking Enter VR triggers native immersive session
- [ ] PC: existing 3D fallback still works (no autoVR param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)