### PR TITLE
feat(panorama): in-VR menu for destination switch + exit (DR-574)

### DIFF
--- a/panorama/src/App.js
+++ b/panorama/src/App.js
@@ -24,6 +24,7 @@ import ImageResizer from './services/ImageResizer';
 import ParisEnvironment from './components/ParisEnvironment';
 import VRDestinationEnvironment from './components/VRDestinationEnvironment';
 import VRPinEntry from './components/VRPinEntry';
+import VRMenu from './components/VR/VRMenu';
 import { getVREnvironment } from './data/environments';
 
 // === COMPOSANTS DE DIAGNOSTIC ===
@@ -412,10 +413,10 @@ function TextureLoadingStatus({ isLoading, loadingState, hasTexture, progress, e
 /**
  * Composant VR Environment - Environnement Paris interactif
  */
-function VREnvironment() {
-  // Récupérer le paramètre destination depuis l'URL
+function VREnvironment({ destination: propDestination, currentSceneId, onSceneChange }) {
+  // Priorité: prop (contrôlée par App) > URL
   const searchParams = new URLSearchParams(window.location.search);
-  const destination = searchParams.get('destination');
+  const destination = propDestination || searchParams.get('destination');
   const showDiagnostics = searchParams.get('debug') === 'true';
 
   // Tous les hooks DOIVENT être appelés avant tout return conditionnel
@@ -474,7 +475,13 @@ function VREnvironment() {
   if (destination) {
     const env = getVREnvironment(destination);
     if (env) {
-      return <VRDestinationEnvironment environment={env} />;
+      return (
+        <VRDestinationEnvironment
+          environment={env}
+          controlledSceneId={currentSceneId}
+          onSceneChange={onSceneChange}
+        />
+      );
     }
   }
 
@@ -577,12 +584,32 @@ function App() {
   // Vérifier le mode debug depuis l'URL
   const searchParams = new URLSearchParams(window.location.search);
   const isDebugMode = searchParams.get('debug') === 'true';
-  const destination = searchParams.get('destination');
+  const urlDestination = searchParams.get('destination');
+
+  // DR-574: destination contrôlée par state pour switch en VR sans rechargement
+  const [destination, setDestination] = useState(urlDestination);
+  // Scène courante (contrôlée) — null = scène par défaut de l'environnement
+  const [currentSceneId, setCurrentSceneId] = useState(null);
+
   const showControls = isDebugMode || !destination; // Masquer les contrôles en mode destination (sauf debug)
 
   const [diagnosticVisible, setDiagnosticVisible] = useState(isDebugMode);
   const initialMode = searchParams.get('mode') || 'auto'; // ?mode=gallery|3d|auto
   const [viewMode, setViewMode] = useState(initialMode);
+
+  // DR-574: handlers pour le menu VR in-session
+  const handleDestinationChange = useCallback((envId) => {
+    setDestination(envId);
+    setCurrentSceneId(null); // Reset sur scène par défaut du nouvel env
+    // Mettre à jour l'URL sans rechargement (garde la session VR active)
+    const params = new URLSearchParams(window.location.search);
+    params.set('destination', envId);
+    window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`);
+  }, []);
+
+  const handleSceneChange = useCallback((sceneId) => {
+    setCurrentSceneId(sceneId);
+  }, []);
 
   // DR-498 / DR-501 / DR-502: Deep Linking for QR Code Access
   const deepLinkState = useVRDeepLink();
@@ -804,8 +831,20 @@ function App() {
               </Text>
             }
           >
-            <VREnvironment />
+            <VREnvironment
+              destination={destination}
+              currentSceneId={currentSceneId}
+              onSceneChange={handleSceneChange}
+            />
           </Suspense>
+
+          {/* DR-574: Menu VR 3D (destinations + scènes + exit) visible en session immersive */}
+          <VRMenu
+            currentDestination={destination}
+            onDestinationChange={handleDestinationChange}
+            currentSceneId={currentSceneId}
+            onSceneChange={handleSceneChange}
+          />
 
           <OrbitControls
             enableZoom={true}

--- a/panorama/src/components/VR/VRMenu.js
+++ b/panorama/src/components/VR/VRMenu.js
@@ -1,0 +1,238 @@
+/**
+ * VRMenu Component - 3D menu visible in immersive VR session
+ *
+ * Ticket: DR-574 (VR Access)
+ *
+ * Affiche un panneau 3D sur la droite du champ de vision contenant :
+ * - Liste des destinations disponibles (changement sans sortir de la VR)
+ * - Liste des scènes de la destination courante
+ * - Bouton "Quitter la VR" qui termine la session WebXR
+ *
+ * Utilise @react-three/xr Interactive pour les events controller/gaze.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Text } from '@react-three/drei';
+import { Interactive, useXR } from '@react-three/xr';
+import { listVREnvironments, VR_ENVIRONMENTS } from '../../data/environments';
+
+/**
+ * Bouton 3D interactif cliquable via controller ray ou gaze
+ */
+function MenuButton({
+  position,
+  label,
+  onClick,
+  color = '#f97316',
+  hoverColor = '#ec4899',
+  textColor = '#ffffff',
+  width = 1.4,
+  height = 0.28,
+  fontSize = 0.1
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <Interactive
+      onSelect={onClick}
+      onHover={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+    >
+      <group position={position}>
+        {/* Background plane */}
+        <mesh onClick={onClick}>
+          <planeGeometry args={[width, height]} />
+          <meshBasicMaterial
+            color={hovered ? hoverColor : color}
+            transparent
+            opacity={0.92}
+          />
+        </mesh>
+        {/* Border glow when hovered */}
+        {hovered && (
+          <mesh position={[0, 0, -0.001]}>
+            <planeGeometry args={[width + 0.04, height + 0.04]} />
+            <meshBasicMaterial color="#ffffff" transparent opacity={0.4} />
+          </mesh>
+        )}
+        {/* Label */}
+        <Text
+          position={[0, 0, 0.01]}
+          fontSize={fontSize}
+          color={textColor}
+          anchorX="center"
+          anchorY="middle"
+          maxWidth={width - 0.1}
+          textAlign="center"
+        >
+          {label}
+        </Text>
+      </group>
+    </Interactive>
+  );
+}
+
+/**
+ * VR Menu principal — panneau flottant à droite du joueur
+ *
+ * @param {Object} props
+ * @param {string} props.currentDestination - ID de la destination actuelle
+ * @param {Function} props.onDestinationChange - Callback pour changer de destination
+ * @param {string} [props.currentSceneId] - ID de la scène actuelle (optionnel)
+ * @param {Function} [props.onSceneChange] - Callback pour changer de scène
+ */
+export default function VRMenu({
+  currentDestination,
+  onDestinationChange,
+  currentSceneId,
+  onSceneChange
+}) {
+  const { isPresenting, session } = useXR();
+  const environments = listVREnvironments();
+
+  const handleExit = useCallback(() => {
+    if (session) {
+      try {
+        session.end();
+      } catch (e) {
+        console.warn('⚠️ Erreur fin de session VR:', e);
+      }
+    }
+  }, [session]);
+
+  const handleDestination = useCallback((envId) => {
+    if (envId !== currentDestination && onDestinationChange) {
+      console.log(`🌍 [VR Menu] Changement destination: ${currentDestination} → ${envId}`);
+      onDestinationChange(envId);
+    }
+  }, [currentDestination, onDestinationChange]);
+
+  const handleScene = useCallback((sceneId) => {
+    if (sceneId !== currentSceneId && onSceneChange) {
+      console.log(`📍 [VR Menu] Changement scène: ${currentSceneId} → ${sceneId}`);
+      onSceneChange(sceneId);
+    }
+  }, [currentSceneId, onSceneChange]);
+
+  // Ne pas afficher le menu en dehors de la session VR
+  if (!isPresenting) return null;
+
+  // Résolution de la destination courante (alias → id canonique)
+  const resolvedDest = currentDestination
+    ? (VR_ENVIRONMENTS[currentDestination.toLowerCase()]
+        ? currentDestination.toLowerCase()
+        : null)
+    : null;
+  const currentEnv = resolvedDest ? VR_ENVIRONMENTS[resolvedDest] : null;
+  const scenes = currentEnv?.scenes || [];
+
+  return (
+    <group position={[1.3, 1.5, -1.4]} rotation={[0, -Math.PI / 6, 0]}>
+      {/* Panneau de fond principal */}
+      <mesh position={[0, 0.1, -0.02]}>
+        <planeGeometry args={[1.7, 2.6]} />
+        <meshBasicMaterial color="#0f172a" transparent opacity={0.9} />
+      </mesh>
+      {/* Bordure orange subtile */}
+      <mesh position={[0, 0.1, -0.025]}>
+        <planeGeometry args={[1.74, 2.64]} />
+        <meshBasicMaterial color="#f97316" transparent opacity={0.5} />
+      </mesh>
+
+      {/* === Header === */}
+      <Text
+        position={[0, 1.28, 0]}
+        fontSize={0.11}
+        color="#f97316"
+        anchorX="center"
+        anchorY="middle"
+      >
+        🌍 DREAMSCAPE VR
+      </Text>
+      <mesh position={[0, 1.16, 0]}>
+        <planeGeometry args={[1.5, 0.004]} />
+        <meshBasicMaterial color="#f97316" />
+      </mesh>
+
+      {/* === Section Destinations === */}
+      <Text
+        position={[0, 1.05, 0]}
+        fontSize={0.08}
+        color="#94a3b8"
+        anchorX="center"
+        anchorY="middle"
+      >
+        DESTINATIONS
+      </Text>
+
+      {environments.map((env, idx) => {
+        const isActive = env.id === resolvedDest;
+        return (
+          <MenuButton
+            key={env.id}
+            position={[0, 0.85 - idx * 0.32, 0]}
+            label={(isActive ? '● ' : '') + env.name}
+            onClick={() => handleDestination(env.id)}
+            color={isActive ? '#ec4899' : '#334155'}
+            hoverColor={isActive ? '#f472b6' : '#475569'}
+            width={1.45}
+            height={0.26}
+            fontSize={0.095}
+          />
+        );
+      })}
+
+      {/* === Section Scènes (si applicable) === */}
+      {scenes.length > 0 && (
+        <>
+          <mesh position={[0, 0.85 - environments.length * 0.32 - 0.05, 0]}>
+            <planeGeometry args={[1.4, 0.003]} />
+            <meshBasicMaterial color="#475569" />
+          </mesh>
+          <Text
+            position={[0, 0.85 - environments.length * 0.32 - 0.15, 0]}
+            fontSize={0.075}
+            color="#94a3b8"
+            anchorX="center"
+            anchorY="middle"
+          >
+            SCÈNES
+          </Text>
+          {scenes.slice(0, 3).map((scene, idx) => {
+            const isActive = scene.id === currentSceneId;
+            const yOffset = 0.85 - environments.length * 0.32 - 0.35 - idx * 0.27;
+            return (
+              <MenuButton
+                key={scene.id}
+                position={[0, yOffset, 0]}
+                label={(scene.icon || '📍') + ' ' + scene.name}
+                onClick={() => handleScene(scene.id)}
+                color={isActive ? '#0891b2' : '#1e293b'}
+                hoverColor={isActive ? '#06b6d4' : '#334155'}
+                width={1.45}
+                height={0.22}
+                fontSize={0.07}
+              />
+            );
+          })}
+        </>
+      )}
+
+      {/* === Bouton Quitter VR (toujours en bas) === */}
+      <mesh position={[0, -1.0, 0]}>
+        <planeGeometry args={[1.5, 0.003]} />
+        <meshBasicMaterial color="#dc2626" transparent opacity={0.6} />
+      </mesh>
+      <MenuButton
+        position={[0, -1.17, 0]}
+        label="✕ Quitter la VR"
+        onClick={handleExit}
+        color="#dc2626"
+        hoverColor="#ef4444"
+        width={1.5}
+        height={0.3}
+        fontSize={0.1}
+      />
+    </group>
+  );
+}

--- a/panorama/src/components/VRDestinationEnvironment.js
+++ b/panorama/src/components/VRDestinationEnvironment.js
@@ -20,12 +20,20 @@ import { NavigationUI, HotspotInfoPanel, TransitionOverlay } from './ParisEnviro
  * @param {Object} props
  * @param {Object} props.environment - Configuration de l'environnement (scenes, defaultScene, name, etc.)
  */
-function VRDestinationEnvironment({ environment }) {
-  const [currentSceneId, setCurrentSceneId] = useState(environment.defaultScene);
+function VRDestinationEnvironment({ environment, controlledSceneId, onSceneChange }) {
+  // Si controlledSceneId fourni, utilise-le; sinon state local initialisé sur defaultScene
+  const [localSceneId, setLocalSceneId] = useState(environment.defaultScene);
+  const currentSceneId = controlledSceneId || localSceneId;
   const [currentScene, setCurrentScene] = useState(null);
   const [loading, setLoading] = useState(true);
   const [sceneHistory, setSceneHistory] = useState([]);
   const [hotspotInfo, setHotspotInfo] = useState(null);
+
+  // Reset sur la scène par défaut quand l'environnement change
+  useEffect(() => {
+    setLocalSceneId(environment.defaultScene);
+    setSceneHistory([]);
+  }, [environment]);
 
   // Charger la scène actuelle depuis les données
   useEffect(() => {
@@ -42,7 +50,15 @@ function VRDestinationEnvironment({ environment }) {
 
   }, [currentSceneId, environment]);
 
-  // Changer de scène (navigation)
+  // Changer de scène (navigation) — propage vers le parent si contrôlé
+  const applySceneChange = useCallback((targetSceneId) => {
+    if (onSceneChange) {
+      onSceneChange(targetSceneId);
+    } else {
+      setLocalSceneId(targetSceneId);
+    }
+  }, [onSceneChange]);
+
   const handleSceneChange = useCallback((targetSceneId) => {
     console.log(`🚀 [${environment.name}] Navigation: ${currentSceneId} → ${targetSceneId}`);
 
@@ -54,11 +70,11 @@ function VRDestinationEnvironment({ environment }) {
 
     // Changer de scène après un court délai pour la transition
     setTimeout(() => {
-      setCurrentSceneId(targetSceneId);
+      applySceneChange(targetSceneId);
       setHotspotInfo(null); // Réinitialiser l'info hotspot
     }, 500);
 
-  }, [currentSceneId, environment.name]);
+  }, [currentSceneId, environment.name, applySceneChange]);
 
   // Revenir à la scène précédente
   const handleGoBack = useCallback(() => {
@@ -71,9 +87,9 @@ function VRDestinationEnvironment({ environment }) {
     console.log(`⬅️ Retour à: ${previousSceneId}`);
 
     setSceneHistory(prev => prev.slice(0, -1));
-    setCurrentSceneId(previousSceneId);
+    applySceneChange(previousSceneId);
 
-  }, [sceneHistory]);
+  }, [sceneHistory, applySceneChange]);
 
   // Interaction avec un hotspot
   const handleHotspotClick = useCallback((hotspot) => {


### PR DESCRIPTION
## Summary
Add a 3D menu panel visible **inside the immersive WebXR session** so the user can:
- Switch between destinations (Paris / Barcelona) without exiting VR
- Browse scenes within the current destination
- Exit the VR session cleanly via \`session.end()\`

## Implementation
- New component \`components/VR/VRMenu.js\`
- Uses \`@react-three/xr\` \`Interactive\` for controller ray hover/select
- Panel floats on user's right (rotated ~30° toward camera)
- \`App.js\` now holds destination + scene state, URL kept in sync via \`history.replaceState\`
- \`VREnvironment\` / \`VRDestinationEnvironment\` accept controlled props

## Test plan
- [ ] Quest 3: enter VR → menu visible on the right
- [ ] Point controller at "Barcelona" button → background glows → trigger → scene reloads with Barcelona texture, still in VR
- [ ] Browse scenes (Eiffel Tower → Louvre, etc.)
- [ ] Click "Quitter la VR" → session ends, back to 3D preview
- [ ] PC: menu does NOT render (isPresenting = false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)