### PR TITLE
feat(web-client): add Vitest config for CI coverage

### DIFF
--- a/web-client/src/test-setup.ts
+++ b/web-client/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/web-client/vitest.config.ts
+++ b/web-client/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'json-summary'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/__tests__/**',
+        'src/main.tsx',
+        'src/vite-env.d.ts',
+      ],
+      // No thresholds — existing tests are spec/aspirational (component labels evolved)
+      // Add thresholds progressively as tests are fixed
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add \`vitest.config.ts\` with jsdom environment, v8 coverage (lcov + json-summary reporters)
- Add \`src/test-setup.ts\` with \`@testing-library/jest-dom\` matchers import

## Why
Enables the \`frontend-tests\` CI job in dreamscape-tests to run \`vitest --coverage\` on the web-client and report to Codecov. Without this config, vitest defaults to \`node\` environment which breaks React/testing-library tests.

## Notes
Existing tests (LoginForm, SignupForm, AuthService) have some failures due to component/test label mismatches — pre-existing, CI step is non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)