### PR TITLE
refactor(footer): fix links, i18n support page & add blog route

### DIFF
--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@stripe/react-stripe-js": "^2.9.0",
         "@stripe/stripe-js": "^2.4.0",
-        "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-table": "^8.21.3",
         "@types/qrcode": "^1.5.6",
         "axios": "^1.7.9",
@@ -150,6 +150,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -528,6 +529,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -551,6 +553,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -639,6 +642,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2020,12 +2024,13 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-2.4.0.tgz",
       "integrity": "sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.95.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
-      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2033,12 +2038,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.95.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
-      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.95.2"
+        "@tanstack/query-core": "5.99.2"
       },
       "funding": {
         "type": "github",
@@ -2176,8 +2181,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2366,6 +2370,7 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2416,6 +2421,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2497,6 +2503,7 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",
@@ -2870,6 +2877,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2907,6 +2915,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3376,6 +3385,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3958,6 +3968,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -4283,8 +4294,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -4434,6 +4444,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -4582,6 +4593,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5698,6 +5710,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -6144,6 +6157,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6512,7 +6526,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6560,6 +6573,7 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.15.0.tgz",
       "integrity": "sha512-fjv+aYrd5TIHiL7wRa+W7KjtUqKWziJMZUkK5hm8TvJ3OLeNPx4NmW/DgfYhd/jHej8wWL+QJBDbdMMAKvNC0A==",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -7236,6 +7250,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7401,7 +7416,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7417,7 +7431,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7550,6 +7563,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7583,6 +7597,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7654,6 +7669,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7785,7 +7801,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8750,6 +8767,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8957,6 +8975,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9156,6 +9175,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9239,6 +9259,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -29,7 +29,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@stripe/react-stripe-js": "^2.9.0",
     "@stripe/stripe-js": "^2.4.0",
-    "@tanstack/react-query": "^5.95.2",
+    "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-table": "^8.21.3",
     "@types/qrcode": "^1.5.6",
     "axios": "^1.7.9",

--- a/web-client/public/locales/en/common.json
+++ b/web-client/public/locales/en/common.json
@@ -173,7 +173,7 @@
     "privacyPolicy": "Privacy Policy",
     "termsOfService": "Terms of Service",
     "cookieSettings": "Cookie Settings",
-    "copyright": "© 2024 DreamScape. All rights reserved."
+    "copyright": "© {{year}} DreamScape. All rights reserved."
   },
   "buttons": {
     "save": "Save",

--- a/web-client/public/locales/en/support.json
+++ b/web-client/public/locales/en/support.json
@@ -9,7 +9,8 @@
     "faq": "FAQ",
     "blog": "Blog",
     "vrTutorials": "VR Tutorials",
-    "sustainability": "Sustainability"
+    "sustainability": "Eco-responsibility",
+    "supportClient": "Customer Support"
   },
   "liveChat": {
     "button": "Need Help?",
@@ -64,5 +65,113 @@
     "planning": "Planning",
     "policies": "Policies",
     "features": "Features"
+  },
+  "guides": {
+    "generatorTitle": "Generate Custom Guide",
+    "destinationLabel": "Destination",
+    "destinationPlaceholder": "Where are you going?",
+    "interestsLabel": "Interests",
+    "generateButton": "Generate Guide",
+    "featuredTitle": "Featured Guides",
+    "interests": {
+      "culture": "Culture",
+      "food": "Food",
+      "adventure": "Adventure",
+      "nature": "Nature",
+      "history": "History",
+      "shopping": "Shopping"
+    },
+    "items": [
+      { "title": "Hidden Gems of Paris", "description": "Discover lesser-known spots and local favorites", "tags": ["Culture", "History"] },
+      { "title": "Tokyo Tech Tour", "description": "Explore the future in Japan's capital", "tags": ["Technology", "Culture"] }
+    ]
+  },
+  "blog": {
+    "readMore": "Read More",
+    "featured": {
+      "title": "The Future of Travel: AI and Virtual Reality",
+      "excerpt": "Explore how emerging technologies are transforming the way we discover and experience destinations..."
+    },
+    "posts": [
+      { "title": "Top Hidden Gems in Southeast Asia", "excerpt": "Discover lesser-known destinations that offer unique cultural experiences and breathtaking views...", "author": "Sarah Johnson", "date": "Feb 15, 2024", "tags": ["Adventure", "Culture"] },
+      { "title": "Sustainable Travel Guide 2024", "excerpt": "Learn how to minimize your environmental impact while exploring the world...", "author": "Mike Chen", "date": "Feb 12, 2024", "tags": ["Eco-Friendly", "Tips"] },
+      { "title": "Using AI to Plan Your Perfect Trip", "excerpt": "How artificial intelligence is revolutionizing the way we plan and experience travel...", "author": "Emma Davis", "date": "Feb 10, 2024", "tags": ["Technology", "Planning"] }
+    ]
+  },
+  "vr": {
+    "quickStartTitle": "Quick Start Guide",
+    "tutorialsTitle": "Tutorial Videos",
+    "downloadResources": "Download Resources",
+    "levels": { "beginner": "Beginner", "intermediate": "Intermediate" },
+    "steps": [
+      { "title": "Setup Your Device", "description": "Connect your VR headset or enable 360° view" },
+      { "title": "Launch Experience", "description": "Start your virtual journey with one click" },
+      { "title": "Follow Tutorial", "description": "Learn the basics with our interactive guide" }
+    ],
+    "tutorials": [
+      { "title": "Getting Started with VR", "duration": "5 min", "level": "beginner", "description": "Learn the basics of using our VR features for immersive travel experiences" },
+      { "title": "Advanced VR Navigation", "duration": "8 min", "level": "intermediate", "description": "Master the art of navigating virtual destinations and interactive features" }
+    ]
+  },
+  "sustainability": {
+    "bannerTitle": "Our Commitment to Sustainability",
+    "bannerText": "We believe in responsible tourism that preserves destinations for future generations. Learn about our initiatives to make travel more sustainable and environmentally conscious.",
+    "impactTitle": "Our Impact",
+    "tipsTitle": "Sustainable Travel Tips",
+    "initiatives": [
+      { "title": "Carbon Offset Program", "description": "We partner with environmental organizations to offset the carbon footprint of your travels" },
+      { "title": "Eco-Friendly Partners", "description": "We work exclusively with accommodations and tour operators committed to sustainable practices" },
+      { "title": "Local Community Support", "description": "A portion of every booking goes directly to supporting local communities" }
+    ],
+    "stats": [
+      { "value": "50K+", "label": "Trees Planted" },
+      { "value": "100K", "label": "CO₂ Offset (tons)" },
+      { "value": "200+", "label": "Local Communities" },
+      { "value": "85%", "label": "Eco-Certified Partners" }
+    ],
+    "tips": [
+      "Choose eco-friendly accommodations",
+      "Support local businesses and artisans",
+      "Use public transportation when possible",
+      "Minimize plastic waste while traveling"
+    ]
+  },
+  "contact": {
+    "channelsTitle": "Our Support Channels",
+    "formTitle": "Send a Message",
+    "formSubtitle": "Our team will get back to you within 24 hours.",
+    "namePlaceholder": "John Doe",
+    "nameLabel": "Full Name",
+    "emailLabel": "Email Address",
+    "emailPlaceholder": "john@example.com",
+    "subjectLabel": "Subject",
+    "subjectPlaceholder": "Select a subject…",
+    "messageLabel": "Message",
+    "messagePlaceholder": "Describe your issue or question in detail…",
+    "submitButton": "Send Message",
+    "successTitle": "Message sent!",
+    "successText": "We have received your request and will get back to you as soon as possible.",
+    "sendAnother": "Send another message",
+    "responseTitle": "Estimated response times",
+    "responseSubtitle": "We do our best to respond within the following timeframes.",
+    "subjects": [
+      "Booking Issue",
+      "Payment Question",
+      "Refund or Cancellation",
+      "Technical Problem",
+      "Account & Login",
+      "VR Experience",
+      "Other"
+    ],
+    "channels": [
+      { "title": "Live Chat", "desc": "Instant response from an advisor", "detail": "Available Mon–Fri · 9am–7pm", "badge": "Online" },
+      { "title": "Email", "desc": "Send us your request in writing", "detail": "support@dreamscape.travel", "badge": "< 24h" },
+      { "title": "Phone", "desc": "Speak directly with an advisor", "detail": "+33 1 80 XX XX XX · Mon–Fri 9am–6pm", "badge": "Free callback" }
+    ],
+    "responseTimes": [
+      { "value": "~2 min", "label": "Chat" },
+      { "value": "< 24h", "label": "Email" },
+      { "value": "< 5 min", "label": "Phone" }
+    ]
   }
 }

--- a/web-client/public/locales/fr/common.json
+++ b/web-client/public/locales/fr/common.json
@@ -171,7 +171,7 @@
     "privacyPolicy": "Politique de confidentialité",
     "termsOfService": "Conditions d'utilisation",
     "cookieSettings": "Paramètres des cookies",
-    "copyright": "© 2024 DreamScape. Tous droits réservés."
+    "copyright": "© {{year}} DreamScape. Tous droits réservés."
   },
   "buttons": {
     "save": "Enregistrer",

--- a/web-client/public/locales/fr/support.json
+++ b/web-client/public/locales/fr/support.json
@@ -9,7 +9,8 @@
     "faq": "FAQ",
     "blog": "Blog",
     "vrTutorials": "Tutoriels VR",
-    "sustainability": "Durabilité"
+    "sustainability": "Éco-responsabilité",
+    "supportClient": "Support client"
   },
   "liveChat": {
     "button": "Besoin d'aide ?",
@@ -62,7 +63,115 @@
   },
   "categories": {
     "planning": "Planification",
-    "policies": "Politiques",
+    "policies": "Conditions",
     "features": "Fonctionnalités"
+  },
+  "guides": {
+    "generatorTitle": "Générer un guide personnalisé",
+    "destinationLabel": "Destination",
+    "destinationPlaceholder": "Où allez-vous ?",
+    "interestsLabel": "Centres d'intérêt",
+    "generateButton": "Générer le guide",
+    "featuredTitle": "Guides à la une",
+    "interests": {
+      "culture": "Culture",
+      "food": "Gastronomie",
+      "adventure": "Aventure",
+      "nature": "Nature",
+      "history": "Histoire",
+      "shopping": "Shopping"
+    },
+    "items": [
+      { "title": "Les trésors cachés de Paris", "description": "Découvrez des endroits méconnus et les coups de cœur des locaux", "tags": ["Culture", "Histoire"] },
+      { "title": "Tokyo Tech Tour", "description": "Explorez le futur dans la capitale du Japon", "tags": ["Technologie", "Culture"] }
+    ]
+  },
+  "blog": {
+    "readMore": "Lire la suite",
+    "featured": {
+      "title": "L'avenir du voyage : IA et Réalité Virtuelle",
+      "excerpt": "Découvrez comment les technologies émergentes transforment la façon dont nous explorons et vivons nos destinations..."
+    },
+    "posts": [
+      { "title": "Les joyaux cachés d'Asie du Sud-Est", "excerpt": "Découvrez des destinations méconnues offrant des expériences culturelles uniques et des paysages à couper le souffle...", "author": "Sarah Johnson", "date": "15 fév. 2024", "tags": ["Aventure", "Culture"] },
+      { "title": "Guide du voyage durable 2024", "excerpt": "Apprenez à réduire votre impact environnemental tout en explorant le monde...", "author": "Mike Chen", "date": "12 fév. 2024", "tags": ["Éco-responsable", "Conseils"] },
+      { "title": "Utiliser l'IA pour planifier le voyage parfait", "excerpt": "Comment l'intelligence artificielle révolutionne la façon dont nous planifions et vivons nos voyages...", "author": "Emma Davis", "date": "10 fév. 2024", "tags": ["Technologie", "Planification"] }
+    ]
+  },
+  "vr": {
+    "quickStartTitle": "Guide de démarrage rapide",
+    "tutorialsTitle": "Vidéos tutorielles",
+    "downloadResources": "Télécharger les ressources",
+    "levels": { "beginner": "Débutant", "intermediate": "Intermédiaire" },
+    "steps": [
+      { "title": "Configurer votre appareil", "description": "Connectez votre casque VR ou activez la vue 360°" },
+      { "title": "Lancer l'expérience", "description": "Démarrez votre voyage virtuel en un clic" },
+      { "title": "Suivre le tutoriel", "description": "Apprenez les bases avec notre guide interactif" }
+    ],
+    "tutorials": [
+      { "title": "Débuter avec la VR", "duration": "5 min", "level": "beginner", "description": "Apprenez les bases de nos fonctionnalités VR pour des expériences de voyage immersives" },
+      { "title": "Navigation VR avancée", "duration": "8 min", "level": "intermediate", "description": "Maîtrisez la navigation dans les destinations virtuelles et les fonctionnalités interactives" }
+    ]
+  },
+  "sustainability": {
+    "bannerTitle": "Notre engagement pour l'éco-responsabilité",
+    "bannerText": "Nous croyons en un tourisme responsable qui préserve les destinations pour les générations futures. Découvrez nos initiatives pour rendre le voyage plus durable et respectueux de l'environnement.",
+    "impactTitle": "Notre impact",
+    "tipsTitle": "Conseils de voyage durable",
+    "initiatives": [
+      { "title": "Programme de compensation carbone", "description": "Nous collaborons avec des organisations environnementales pour compenser l'empreinte carbone de vos voyages" },
+      { "title": "Partenaires éco-responsables", "description": "Nous travaillons exclusivement avec des hébergements et des opérateurs engagés dans des pratiques durables" },
+      { "title": "Soutien aux communautés locales", "description": "Une partie de chaque réservation est reversée directement au soutien des communautés locales" }
+    ],
+    "stats": [
+      { "value": "50K+", "label": "Arbres plantés" },
+      { "value": "100K", "label": "CO₂ compensé (tonnes)" },
+      { "value": "200+", "label": "Communautés locales" },
+      { "value": "85%", "label": "Partenaires éco-certifiés" }
+    ],
+    "tips": [
+      "Choisissez des hébergements éco-responsables",
+      "Soutenez les commerces et artisans locaux",
+      "Utilisez les transports en commun autant que possible",
+      "Réduisez vos déchets plastiques en voyage"
+    ]
+  },
+  "contact": {
+    "channelsTitle": "Nos canaux de support",
+    "formTitle": "Envoyer un message",
+    "formSubtitle": "Notre équipe vous répondra dans les 24 heures.",
+    "nameLabel": "Nom complet",
+    "namePlaceholder": "Jean Dupont",
+    "emailLabel": "Adresse e-mail",
+    "emailPlaceholder": "jean@exemple.fr",
+    "subjectLabel": "Sujet",
+    "subjectPlaceholder": "Sélectionnez un sujet…",
+    "messageLabel": "Message",
+    "messagePlaceholder": "Décrivez votre problème ou votre question en détail…",
+    "submitButton": "Envoyer le message",
+    "successTitle": "Message envoyé !",
+    "successText": "Nous avons bien reçu votre demande et vous répondrons dans les plus brefs délais.",
+    "sendAnother": "Envoyer un autre message",
+    "responseTitle": "Délais de réponse estimés",
+    "responseSubtitle": "Nous faisons notre maximum pour répondre dans les délais suivants.",
+    "subjects": [
+      "Problème de réservation",
+      "Question sur un paiement",
+      "Remboursement ou annulation",
+      "Problème technique",
+      "Compte et connexion",
+      "Expérience VR",
+      "Autre"
+    ],
+    "channels": [
+      { "title": "Chat en direct", "desc": "Réponse instantanée avec un conseiller", "detail": "Disponible lun–ven · 9h–19h", "badge": "En ligne" },
+      { "title": "E-mail", "desc": "Envoyez-nous votre demande par écrit", "detail": "support@dreamscape.travel", "badge": "< 24 h" },
+      { "title": "Téléphone", "desc": "Parlez directement à un conseiller", "detail": "+33 1 80 XX XX XX · lun–ven 9h–18h", "badge": "Rappel gratuit" }
+    ],
+    "responseTimes": [
+      { "value": "~2 min", "label": "Chat" },
+      { "value": "< 24h", "label": "E-mail" },
+      { "value": "< 5 min", "label": "Téléphone" }
+    ]
   }
 }

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -58,6 +58,7 @@ import PrivacyPolicyPage from '@/pages/legal/PrivacyPolicy';
 // Help & FAQ Pages
 import HelpPage from '@/pages/help';
 import FaqPage from '@/pages/faq';
+import BlogPage from '@/pages/blog';
 
 // GDPR
 import CookieConsent from '@/components/gdpr/CookieConsent';
@@ -173,6 +174,7 @@ function App() {
             <Route path="/support" element={<SupportPage />} />
             <Route path="/help" element={<HelpPage />} />
             <Route path="/faq" element={<FaqPage />} />
+            <Route path="/blog" element={<BlogPage />} />
 
             {/* Legal Routes */}
             <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />

--- a/web-client/src/components/layout/Footer.tsx
+++ b/web-client/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Plane, Instagram, Twitter, Facebook, Youtube, Send } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Plane, Linkedin, Send } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import LanguageSelector from '@/components/common/LanguageSelector';
+
 
 const Footer = () => {
   const { t } = useTranslation('common');
@@ -21,15 +21,14 @@ const Footer = () => {
               {t('footer.description')}
             </p>
             <div className="flex gap-4">
-              {[Instagram, Twitter, Facebook, Youtube].map((Icon, index) => (
-                <a
-                  key={index}
-                  href="#"
-                  className="w-10 h-10 rounded-full flex items-center justify-center bg-gradient-to-r from-orange-400/10 to-pink-600/10 hover:from-orange-400 hover:to-pink-600 group transition-all duration-300"
-                >
-                  <Icon className="w-5 h-5 text-gray-600 group-hover:text-white transition-colors" />
-                </a>
-              ))}
+              <a
+                href="https://www.linkedin.com/company/dreamscape-ai/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-10 h-10 rounded-full flex items-center justify-center bg-gradient-to-r from-orange-400/10 to-pink-600/10 hover:from-orange-400 hover:to-pink-600 group transition-all duration-300"
+              >
+                <Linkedin className="w-5 h-5 text-gray-600 group-hover:text-white transition-colors" />
+              </a>
             </div>
           </div>
 
@@ -45,9 +44,9 @@ const Footer = () => {
                 { key: 'hiddenGems', label: t('footer.hiddenGems') }
               ].map((item) => (
                 <li key={item.key}>
-                  <a href="#" className="text-gray-600 hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">
+                  <Link to="/destinations" className="text-gray-600 hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">
                     {item.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -57,16 +56,16 @@ const Footer = () => {
             <h3 className="text-lg font-semibold mb-6 text-gray-800">{t('footer.resources')}</h3>
             <ul className="space-y-3">
               {[
-                { key: 'travelGuide', label: t('footer.travelGuide') },
-                { key: 'faqs', label: t('footer.faqs') },
-                { key: 'customerSupport', label: t('footer.customerSupport') },
-                { key: 'travelInsurance', label: t('footer.travelInsurance') },
-                { key: 'blog', label: t('footer.blog') }
+                { key: 'travelGuide', label: t('footer.travelGuide'), to: '/help#section-prise-en-main' },
+                { key: 'faqs', label: t('footer.faqs'), to: '/faq' },
+                { key: 'customerSupport', label: t('footer.customerSupport'), to: '/support' },
+                { key: 'travelInsurance', label: t('footer.travelInsurance'), to: '/help#section-paiement' },
+                { key: 'blog', label: t('footer.blog'), to: '/blog' }
               ].map((item) => (
                 <li key={item.key}>
-                  <a href="#" className="text-gray-600 hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">
+                  <Link to={item.to} className="text-gray-600 hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">
                     {item.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -95,14 +94,11 @@ const Footer = () => {
       {/* Bottom Bar */}
       <div className="border-t border-gray-200">
         <div className="container mx-auto px-4 py-6">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="flex flex-wrap gap-6 text-sm text-gray-600">
-              <a href="#" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.privacyPolicy')}</a>
-              <a href="#" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.termsOfService')}</a>
-              <a href="#" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.cookieSettings')}</a>
-              <span>{t('footer.copyright')}</span>
-            </div>
-            <LanguageSelector variant="full" />
+          <div className="flex flex-wrap gap-6 text-sm text-gray-600">
+            <Link to="/help#section-rgpd" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.privacyPolicy')}</Link>
+            <Link to="/help#section-rgpd" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.termsOfService')}</Link>
+            <Link to="/help#section-rgpd" className="hover:text-orange-500 transition-colors focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none rounded">{t('footer.cookieSettings')}</Link>
+            <span>{t('footer.copyright', { year: new Date().getFullYear() })}</span>
           </div>
         </div>
       </div>

--- a/web-client/src/components/support/AIGuides.tsx
+++ b/web-client/src/components/support/AIGuides.tsx
@@ -1,43 +1,33 @@
-import React, { useState } from 'react';
-import { Globe, MapPin, Compass, Sparkles } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MapPin, Sparkles } from 'lucide-react';
+
+interface GuideItem { title: string; description: string; tags: string[] }
 
 const AIGuides = () => {
+  const { t } = useTranslation('support');
   const [destination, setDestination] = useState('');
   const [interests, setInterests] = useState<string[]>([]);
 
-  const availableInterests = [
-    'Culture', 'Food', 'Adventure', 'Nature', 'History', 'Shopping'
-  ];
+  const availableInterests = Object.entries(
+    t('guides.interests', { returnObjects: true }) as Record<string, string>
+  );
+  const guides = t('guides.items', { returnObjects: true }) as GuideItem[];
 
-  const guides = [
-    {
-      title: "Hidden Gems of Paris",
-      description: "Discover lesser-known spots and local favorites",
-      image: "https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&q=80",
-      tags: ['Culture', 'History']
-    },
-    {
-      title: "Tokyo Tech Tour",
-      description: "Explore the future in Japan's capital",
-      image: "https://images.unsplash.com/photo-1540959733332-eab4deabeeaf?auto=format&fit=crop&q=80",
-      tags: ['Technology', 'Culture']
-    }
-  ];
+  const toggleInterest = (key: string) => {
+    setInterests(prev => prev.includes(key) ? prev.filter(i => i !== key) : [...prev, key]);
+  };
 
   return (
     <div className="space-y-8">
-      {/* AI Guide Generator */}
       <div className="bg-white rounded-xl shadow-sm p-6">
         <div className="flex items-center gap-2 mb-6">
           <Sparkles className="w-5 h-5 text-orange-500" />
-          <h2 className="text-xl font-semibold">Generate Custom Guide</h2>
+          <h2 className="text-xl font-semibold">{t('guides.generatorTitle')}</h2>
         </div>
-
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Destination
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-2">{t('guides.destinationLabel')}</label>
             <div className="relative">
               <div className="absolute inset-y-0 left-4 flex items-center">
                 <MapPin className="w-5 h-5 text-gray-400" />
@@ -46,72 +36,44 @@ const AIGuides = () => {
                 type="text"
                 value={destination}
                 onChange={(e) => setDestination(e.target.value)}
-                placeholder="Where are you going?"
+                placeholder={t('guides.destinationPlaceholder')}
                 className="w-full pl-12 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500/20"
               />
             </div>
           </div>
-
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Interests
-            </label>
+            <label className="block text-sm font-medium text-gray-700 mb-2">{t('guides.interestsLabel')}</label>
             <div className="flex flex-wrap gap-2">
-              {availableInterests.map((interest) => (
+              {availableInterests.map(([key, label]) => (
                 <button
-                  key={interest}
-                  onClick={() => {
-                    if (interests.includes(interest)) {
-                      setInterests(interests.filter(i => i !== interest));
-                    } else {
-                      setInterests([...interests, interest]);
-                    }
-                  }}
+                  key={key}
+                  onClick={() => toggleInterest(key)}
                   className={`px-4 py-2 rounded-lg text-sm transition-colors ${
-                    interests.includes(interest)
-                      ? 'bg-orange-500 text-white'
-                      : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
+                    interests.includes(key) ? 'bg-orange-500 text-white' : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
                   }`}
                 >
-                  {interest}
+                  {label}
                 </button>
               ))}
             </div>
           </div>
-
           <button className="w-full py-3 bg-gradient-to-r from-orange-500 to-pink-500 text-white rounded-lg hover:opacity-90 transition-opacity">
-            Generate Guide
+            {t('guides.generateButton')}
           </button>
         </div>
       </div>
 
-      {/* Featured Guides */}
       <div>
-        <h2 className="text-xl font-semibold mb-4">Featured Guides</h2>
+        <h2 className="text-xl font-semibold mb-4">{t('guides.featuredTitle')}</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {guides.map((guide, index) => (
-            <div
-              key={index}
-              className="group bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow"
-            >
-              <div className="aspect-[16/9] overflow-hidden">
-                <img
-                  src={guide.image}
-                  alt={guide.title}
-                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
-                />
-              </div>
+          {guides.map((guide, i) => (
+            <div key={i} className="group bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow">
               <div className="p-6">
                 <h3 className="text-lg font-semibold mb-2">{guide.title}</h3>
                 <p className="text-gray-600 mb-4">{guide.description}</p>
                 <div className="flex flex-wrap gap-2">
                   {guide.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="px-3 py-1 bg-orange-50 text-orange-600 rounded-full text-sm"
-                    >
-                      {tag}
-                    </span>
+                    <span key={tag} className="px-3 py-1 bg-orange-50 text-orange-600 rounded-full text-sm">{tag}</span>
                   ))}
                 </div>
               </div>

--- a/web-client/src/components/support/BlogSection.tsx
+++ b/web-client/src/components/support/BlogSection.tsx
@@ -1,104 +1,65 @@
-import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Calendar, User, ArrowRight, Tag } from 'lucide-react';
 
+interface BlogPost { title: string; excerpt: string; author: string; date: string; tags: string[] }
+
 const BlogSection = () => {
-  const posts = [
-    {
-      title: "Top Hidden Gems in Southeast Asia",
-      excerpt: "Discover lesser-known destinations that offer unique cultural experiences and breathtaking views...",
-      image: "https://images.unsplash.com/photo-1528181304800-259b08848526?auto=format&fit=crop&q=80",
-      author: "Sarah Johnson",
-      date: "Feb 15, 2024",
-      tags: ["Adventure", "Culture"]
-    },
-    {
-      title: "Sustainable Travel Guide 2024",
-      excerpt: "Learn how to minimize your environmental impact while exploring the world...",
-      image: "https://images.unsplash.com/photo-1493246507139-91e8fad9978e?auto=format&fit=crop&q=80",
-      author: "Mike Chen",
-      date: "Feb 12, 2024",
-      tags: ["Eco-Friendly", "Tips"]
-    },
-    {
-      title: "Using AI to Plan Your Perfect Trip",
-      excerpt: "How artificial intelligence is revolutionizing the way we plan and experience travel...",
-      image: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&q=80",
-      author: "Emma Davis",
-      date: "Feb 10, 2024",
-      tags: ["Technology", "Planning"]
-    }
-  ];
+  const { t } = useTranslation('support');
+  const posts = t('blog.posts', { returnObjects: true }) as BlogPost[];
+  const featured = t('blog.featured', { returnObjects: true }) as { title: string; excerpt: string };
 
   return (
     <div className="space-y-8">
-      {/* Featured Post */}
       <div className="relative h-[400px] rounded-xl overflow-hidden">
         <img
           src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&q=80"
-          alt="Featured post"
+          alt={featured.title}
           className="w-full h-full object-cover"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
         <div className="absolute bottom-0 left-0 right-0 p-8">
           <div className="max-w-2xl">
             <div className="flex items-center gap-4 text-white/80 mb-4">
-              <div className="flex items-center gap-2">
-                <Calendar className="w-4 h-4" />
-                <span>Feb 20, 2024</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <User className="w-4 h-4" />
-                <span>Alex Thompson</span>
-              </div>
+              <div className="flex items-center gap-2"><Calendar className="w-4 h-4" /><span>20 fév. 2024</span></div>
+              <div className="flex items-center gap-2"><User className="w-4 h-4" /><span>Alex Thompson</span></div>
             </div>
-            <h2 className="text-3xl font-bold text-white mb-4">
-              The Future of Travel: AI and Virtual Reality
-            </h2>
-            <p className="text-white/80 mb-6">
-              Explore how emerging technologies are transforming the way we discover and experience destinations...
-            </p>
+            <h2 className="text-3xl font-bold text-white mb-4">{featured.title}</h2>
+            <p className="text-white/80 mb-6">{featured.excerpt}</p>
             <button className="flex items-center gap-2 text-white hover:text-orange-400 transition-colors">
-              <span>Read More</span>
+              <span>{t('blog.readMore')}</span>
               <ArrowRight className="w-4 h-4" />
             </button>
           </div>
         </div>
       </div>
 
-      {/* Recent Posts Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        {posts.map((post, index) => (
-          <div key={index} className="bg-white rounded-xl shadow-sm overflow-hidden">
+        {posts.map((post, i) => (
+          <div key={i} className="bg-white rounded-xl shadow-sm overflow-hidden">
             <div className="aspect-[16/9] overflow-hidden">
               <img
-                src={post.image}
+                src={[
+                  'https://images.unsplash.com/photo-1528181304800-259b08848526?auto=format&fit=crop&q=80',
+                  'https://images.unsplash.com/photo-1493246507139-91e8fad9978e?auto=format&fit=crop&q=80',
+                  'https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&q=80',
+                ][i]}
                 alt={post.title}
                 className="w-full h-full object-cover transition-transform duration-300 hover:scale-110"
               />
             </div>
             <div className="p-6">
               <div className="flex flex-wrap gap-2 mb-4">
-                {post.tags.map((tag, tagIndex) => (
-                  <span
-                    key={tagIndex}
-                    className="flex items-center gap-1 px-3 py-1 bg-orange-50 text-orange-600 rounded-full text-sm"
-                  >
-                    <Tag className="w-3 h-3" />
-                    {tag}
+                {post.tags.map((tag, ti) => (
+                  <span key={ti} className="flex items-center gap-1 px-3 py-1 bg-orange-50 text-orange-600 rounded-full text-sm">
+                    <Tag className="w-3 h-3" />{tag}
                   </span>
                 ))}
               </div>
               <h3 className="text-xl font-semibold mb-2">{post.title}</h3>
               <p className="text-gray-600 mb-4">{post.excerpt}</p>
               <div className="flex items-center justify-between text-sm text-gray-500">
-                <div className="flex items-center gap-2">
-                  <User className="w-4 h-4" />
-                  <span>{post.author}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Calendar className="w-4 h-4" />
-                  <span>{post.date}</span>
-                </div>
+                <div className="flex items-center gap-2"><User className="w-4 h-4" /><span>{post.author}</span></div>
+                <div className="flex items-center gap-2"><Calendar className="w-4 h-4" /><span>{post.date}</span></div>
               </div>
             </div>
           </div>

--- a/web-client/src/components/support/DynamicFAQ.tsx
+++ b/web-client/src/components/support/DynamicFAQ.tsx
@@ -1,64 +1,46 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, ThumbsUp, ThumbsDown, Search } from 'lucide-react';
 
 const DynamicFAQ = () => {
+  const { t } = useTranslation('support');
   const [openQuestion, setOpenQuestion] = useState<number | null>(null);
   const [helpfulAnswers, setHelpfulAnswers] = useState<Record<number, boolean>>({});
   const [searchQuery, setSearchQuery] = useState('');
 
   const faqs = [
     {
-      category: 'Booking & Reservations',
+      category: t('faq.categories.booking'),
       questions: [
-        {
-          id: 1,
-          question: 'How do I modify or cancel my booking?',
-          answer: 'You can modify or cancel your booking through your account dashboard. Go to "My Trips" and select the booking you wish to change. Please note that cancellation policies vary depending on the type of booking and how far in advance you cancel.'
-        },
-        {
-          id: 2,
-          question: 'What payment methods do you accept?',
-          answer: 'We accept all major credit cards (Visa, MasterCard, American Express), PayPal, and various local payment methods depending on your region. All payments are processed securely through our payment partners.'
-        }
-      ]
+        { id: 1, question: t('faq.questions.modifyBooking'), answer: t('faq.questions.modifyBookingAnswer') },
+        { id: 2, question: t('faq.questions.paymentMethods'), answer: t('faq.questions.paymentMethodsAnswer') },
+      ],
     },
     {
-      category: 'Using AI Features',
+      category: t('faq.categories.aiFeatures'),
       questions: [
-        {
-          id: 3,
-          question: 'How does the AI trip planner work?',
-          answer: 'Our AI trip planner analyzes your preferences, travel history, and current trends to create personalized itineraries. It considers factors like weather, local events, and your interests to suggest the best experiences for you.'
-        },
-        {
-          id: 4,
-          question: 'Can I customize AI recommendations?',
-          answer: 'Yes! You can fine-tune AI recommendations by adjusting your preferences in your profile settings. You can also modify suggested itineraries directly and the AI will learn from your changes for future recommendations.'
-        }
-      ]
-    }
+        { id: 3, question: t('faq.questions.aiPlanner'), answer: t('faq.questions.aiPlannerAnswer') },
+        { id: 4, question: t('faq.questions.customizeAI'), answer: t('faq.questions.customizeAIAnswer') },
+      ],
+    },
   ];
 
-  const handleFeedback = (questionId: number, isHelpful: boolean) => {
-    setHelpfulAnswers({ ...helpfulAnswers, [questionId]: isHelpful });
-    // Here you could also send analytics or store the feedback
-  };
-
-  const filteredFaqs = faqs.map(category => ({
-    ...category,
-    questions: category.questions.filter(q => 
-      q.question.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      q.answer.toLowerCase().includes(searchQuery.toLowerCase())
-    )
-  })).filter(category => category.questions.length > 0);
+  const filteredFaqs = faqs
+    .map(cat => ({
+      ...cat,
+      questions: cat.questions.filter(
+        q => q.question.toLowerCase().includes(searchQuery.toLowerCase()) ||
+             q.answer.toLowerCase().includes(searchQuery.toLowerCase())
+      ),
+    }))
+    .filter(cat => cat.questions.length > 0);
 
   return (
     <div className="space-y-8">
-      {/* Search Bar */}
       <div className="relative">
         <input
           type="text"
-          placeholder="Search FAQ..."
+          placeholder={t('faq.searchPlaceholder')}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full px-4 py-3 pl-12 bg-white border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500/20"
@@ -66,56 +48,37 @@ const DynamicFAQ = () => {
         <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
       </div>
 
-      {filteredFaqs.map((category, categoryIndex) => (
-        <div key={categoryIndex}>
+      {filteredFaqs.map((category, ci) => (
+        <div key={ci}>
           <h2 className="text-xl font-semibold mb-4">{category.category}</h2>
           <div className="space-y-4">
             {category.questions.map((faq) => (
-              <div
-                key={faq.id}
-                className="bg-white rounded-xl shadow-sm overflow-hidden transition-all duration-200"
-              >
+              <div key={faq.id} className="bg-white rounded-xl shadow-sm overflow-hidden">
                 <button
                   onClick={() => setOpenQuestion(openQuestion === faq.id ? null : faq.id)}
                   className="w-full flex items-center justify-between p-6 text-left hover:bg-gray-50 transition-colors"
                 >
                   <span className="font-medium">{faq.question}</span>
-                  {openQuestion === faq.id ? (
-                    <ChevronUp className="w-5 h-5 text-gray-400" />
-                  ) : (
-                    <ChevronDown className="w-5 h-5 text-gray-400" />
-                  )}
+                  {openQuestion === faq.id
+                    ? <ChevronUp className="w-5 h-5 text-gray-400" />
+                    : <ChevronDown className="w-5 h-5 text-gray-400" />}
                 </button>
-
                 {openQuestion === faq.id && (
-                  <div className="px-6 pb-6 animate-fadeIn">
+                  <div className="px-6 pb-6">
                     <div className="pt-4 border-t border-gray-100">
                       <p className="text-gray-600 mb-4">{faq.answer}</p>
-                      
-                      {helpfulAnswers[faq.id] === undefined && (
+                      {helpfulAnswers[faq.id] === undefined ? (
                         <div className="flex items-center gap-4 text-sm text-gray-500">
-                          <span>Was this answer helpful?</span>
-                          <button
-                            onClick={() => handleFeedback(faq.id, true)}
-                            className="flex items-center gap-1 hover:text-green-500 transition-colors"
-                          >
-                            <ThumbsUp className="w-4 h-4" />
-                            Yes
+                          <span>{t('faq.feedback.question')}</span>
+                          <button onClick={() => setHelpfulAnswers({ ...helpfulAnswers, [faq.id]: true })} className="flex items-center gap-1 hover:text-green-500 transition-colors">
+                            <ThumbsUp className="w-4 h-4" />{t('faq.feedback.yes')}
                           </button>
-                          <button
-                            onClick={() => handleFeedback(faq.id, false)}
-                            className="flex items-center gap-1 hover:text-red-500 transition-colors"
-                          >
-                            <ThumbsDown className="w-4 h-4" />
-                            No
+                          <button onClick={() => setHelpfulAnswers({ ...helpfulAnswers, [faq.id]: false })} className="flex items-center gap-1 hover:text-red-500 transition-colors">
+                            <ThumbsDown className="w-4 h-4" />{t('faq.feedback.no')}
                           </button>
                         </div>
-                      )}
-                      
-                      {helpfulAnswers[faq.id] !== undefined && (
-                        <div className="text-sm text-gray-500">
-                          Thank you for your feedback!
-                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-500">{t('faq.feedback.thanks')}</p>
                       )}
                     </div>
                   </div>
@@ -127,9 +90,7 @@ const DynamicFAQ = () => {
       ))}
 
       {filteredFaqs.length === 0 && (
-        <div className="text-center py-8 text-gray-500">
-          No FAQ matches your search. Try different keywords or browse all questions.
-        </div>
+        <div className="text-center py-8 text-gray-500">{t('search.noResults')}</div>
       )}
     </div>
   );

--- a/web-client/src/components/support/HelpSearch.tsx
+++ b/web-client/src/components/support/HelpSearch.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Search, ArrowRight, Star, Clock } from 'lucide-react';
 
 interface HelpSearchProps {
@@ -6,34 +7,18 @@ interface HelpSearchProps {
 }
 
 const HelpSearch: React.FC<HelpSearchProps> = ({ initialQuery = '' }) => {
+  const { t } = useTranslation('support');
   const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  
-  const popularTopics = [
-    'How to plan an itinerary',
-    'Booking cancellation policy',
-    'VR experience setup',
-    'Payment methods',
-    'Travel insurance'
-  ];
+
+  const popularTopics = t('topics', { returnObjects: true }) as Record<string, string>;
+  const topicList = Object.values(popularTopics);
 
   const searchResults = [
-    {
-      title: 'How to create and share travel plans',
-      category: 'Planning',
-      relevance: 98
-    },
-    {
-      title: 'Understanding our booking protection',
-      category: 'Policies',
-      relevance: 95
-    },
-    {
-      title: 'Using AI recommendations',
-      category: 'Features',
-      relevance: 92
-    }
+    { titleKey: 'topics.createPlan', categoryKey: 'categories.planning', relevance: 98 },
+    { titleKey: 'topics.protection', categoryKey: 'categories.policies', relevance: 95 },
+    { titleKey: 'topics.aiRecommendations', categoryKey: 'categories.features', relevance: 92 },
   ];
 
   useEffect(() => {
@@ -46,8 +31,6 @@ const HelpSearch: React.FC<HelpSearchProps> = ({ initialQuery = '' }) => {
   const handleSearch = (query: string) => {
     setSearchQuery(query);
     setIsSearching(true);
-    
-    // Simulate search delay
     setTimeout(() => {
       setIsSearching(false);
       if (query && !recentSearches.includes(query)) {
@@ -56,59 +39,43 @@ const HelpSearch: React.FC<HelpSearchProps> = ({ initialQuery = '' }) => {
     }, 500);
   };
 
-  const handleTopicClick = (topic: string) => {
-    setSearchQuery(topic);
-    handleSearch(topic);
-  };
-
   return (
     <div className="space-y-8">
-      {/* Search Bar */}
       <div className="relative">
         <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
           <Search className="w-5 h-5 text-gray-400" />
         </div>
         <input
           type="text"
-          placeholder="Search for help articles..."
+          placeholder={t('search.placeholder')}
           value={searchQuery}
           onChange={(e) => handleSearch(e.target.value)}
           className="w-full pl-12 pr-4 py-3 bg-white border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500/20"
         />
       </div>
 
-      {/* Recent Searches */}
       {recentSearches.length > 0 && !searchQuery && (
         <div>
           <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
             <Clock className="w-5 h-5 text-gray-400" />
-            Recent Searches
+            {t('search.recentSearches')}
           </h2>
           <div className="flex flex-wrap gap-2">
-            {recentSearches.map((search, index) => (
-              <button
-                key={index}
-                onClick={() => handleTopicClick(search)}
-                className="px-4 py-2 bg-gray-50 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors"
-              >
-                {search}
+            {recentSearches.map((s, i) => (
+              <button key={i} onClick={() => handleSearch(s)} className="px-4 py-2 bg-gray-50 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors">
+                {s}
               </button>
             ))}
           </div>
         </div>
       )}
 
-      {/* Popular Topics */}
       {!searchQuery && (
         <div>
-          <h2 className="text-xl font-semibold mb-4">Popular Topics</h2>
+          <h2 className="text-xl font-semibold mb-4">{t('search.popularTopics')}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {popularTopics.map((topic, index) => (
-              <button
-                key={index}
-                onClick={() => handleTopicClick(topic)}
-                className="flex items-center justify-between p-4 bg-white rounded-xl border border-gray-100 hover:border-orange-500 transition-colors group"
-              >
+            {topicList.map((topic, i) => (
+              <button key={i} onClick={() => handleSearch(topic)} className="flex items-center justify-between p-4 bg-white rounded-xl border border-gray-100 hover:border-orange-500 transition-colors group">
                 <span className="text-gray-700 group-hover:text-orange-500">{topic}</span>
                 <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-orange-500" />
               </button>
@@ -117,23 +84,19 @@ const HelpSearch: React.FC<HelpSearchProps> = ({ initialQuery = '' }) => {
         </div>
       )}
 
-      {/* Search Results */}
       {searchQuery && !isSearching && (
         <div className="space-y-4">
-          <h2 className="text-xl font-semibold">Search Results</h2>
-          {searchResults.map((result, index) => (
-            <button
-              key={index}
-              className="w-full p-4 bg-white rounded-xl border border-gray-100 hover:border-orange-500 transition-colors cursor-pointer text-left"
-            >
+          <h2 className="text-xl font-semibold">{t('search.title')}</h2>
+          {searchResults.map((r, i) => (
+            <button key={i} className="w-full p-4 bg-white rounded-xl border border-gray-100 hover:border-orange-500 transition-colors cursor-pointer text-left">
               <div className="flex items-start justify-between">
                 <div>
-                  <h3 className="font-medium mb-1">{result.title}</h3>
-                  <span className="text-sm text-gray-500">{result.category}</span>
+                  <h3 className="font-medium mb-1">{t(r.titleKey)}</h3>
+                  <span className="text-sm text-gray-500">{t(r.categoryKey)}</span>
                 </div>
                 <div className="flex items-center gap-1 text-sm text-orange-500">
                   <Star className="w-4 h-4 fill-orange-500" />
-                  {result.relevance}% match
+                  {t('search.relevance', { percent: r.relevance })}
                 </div>
               </div>
             </button>
@@ -141,7 +104,6 @@ const HelpSearch: React.FC<HelpSearchProps> = ({ initialQuery = '' }) => {
         </div>
       )}
 
-      {/* Loading State */}
       {isSearching && (
         <div className="flex justify-center py-8">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500" />

--- a/web-client/src/components/support/LiveChat.tsx
+++ b/web-client/src/components/support/LiveChat.tsx
@@ -1,106 +1,58 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Send, X, Bot, User } from 'lucide-react';
 
 interface LiveChatProps {
   onClose: () => void;
 }
 
-const LiveChat: React.FC<LiveChatProps> = ({ onClose }) => {
+const LiveChat = ({ onClose }: LiveChatProps) => {
+  const { t } = useTranslation('support');
   const [messages, setMessages] = useState([
-    {
-      type: 'bot',
-      content: 'Hello! How can I help you today?',
-      timestamp: new Date().toISOString()
-    }
+    { type: 'bot', content: t('liveChat.greeting'), timestamp: new Date().toISOString() },
   ]);
   const [input, setInput] = useState('');
 
   const handleSend = () => {
     if (!input.trim()) return;
-
-    setMessages([
-      ...messages,
-      {
-        type: 'user',
-        content: input,
-        timestamp: new Date().toISOString()
-      }
-    ]);
+    setMessages(prev => [...prev, { type: 'user', content: input, timestamp: new Date().toISOString() }]);
     setInput('');
-
-    // Simulate bot response
     setTimeout(() => {
-      setMessages(prev => [
-        ...prev,
-        {
-          type: 'bot',
-          content: 'Thank you for your message. A support agent will respond shortly.',
-          timestamp: new Date().toISOString()
-        }
-      ]);
+      setMessages(prev => [...prev, { type: 'bot', content: t('liveChat.autoResponse'), timestamp: new Date().toISOString() }]);
     }, 1000);
   };
 
   return (
     <div className="fixed bottom-6 right-6 w-96 bg-white rounded-xl shadow-lg overflow-hidden z-50">
-      {/* Header */}
       <div className="bg-gradient-to-r from-orange-500 to-pink-500 p-4 text-white">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Bot className="w-6 h-6" />
             <div>
-              <h3 className="font-semibold">Support Chat</h3>
-              <p className="text-sm text-white/80">We typically reply in a few minutes</p>
+              <h3 className="font-semibold">{t('liveChat.title')}</h3>
+              <p className="text-sm text-white/80">{t('liveChat.subtitle')}</p>
             </div>
           </div>
-          <button
-            onClick={onClose}
-            className="p-1 hover:bg-white/20 rounded-full transition-colors"
-          >
+          <button onClick={onClose} className="p-1 hover:bg-white/20 rounded-full transition-colors">
             <X className="w-5 h-5" />
           </button>
         </div>
       </div>
 
-      {/* Chat Messages */}
       <div className="h-96 overflow-y-auto p-4 space-y-4">
-        {messages.map((message, index) => (
-          <div
-            key={index}
-            className={`flex items-start gap-3 ${
-              message.type === 'user' ? 'flex-row-reverse' : ''
-            }`}
-          >
-            <div
-              className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
-                message.type === 'user'
-                  ? 'bg-orange-100'
-                  : 'bg-gray-100'
-              }`}
-            >
-              {message.type === 'user' ? (
-                <User className="w-5 h-5 text-orange-500" />
-              ) : (
-                <Bot className="w-5 h-5 text-gray-600" />
-              )}
+        {messages.map((msg, i) => (
+          <div key={i} className={`flex items-start gap-3 ${msg.type === 'user' ? 'flex-row-reverse' : ''}`}>
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${msg.type === 'user' ? 'bg-orange-100' : 'bg-gray-100'}`}>
+              {msg.type === 'user' ? <User className="w-5 h-5 text-orange-500" /> : <Bot className="w-5 h-5 text-gray-600" />}
             </div>
-            <div
-              className={`max-w-[70%] rounded-lg p-3 ${
-                message.type === 'user'
-                  ? 'bg-orange-500 text-white'
-                  : 'bg-gray-100 text-gray-800'
-              }`}
-            >
-              <p className="text-sm">{message.content}</p>
-              <span className="text-xs opacity-70 mt-1 block">
-                {new Date(message.timestamp).toLocaleTimeString()}
-              </span>
+            <div className={`max-w-[70%] rounded-lg p-3 ${msg.type === 'user' ? 'bg-orange-500 text-white' : 'bg-gray-100 text-gray-800'}`}>
+              <p className="text-sm">{msg.content}</p>
+              <span className="text-xs opacity-70 mt-1 block">{new Date(msg.timestamp).toLocaleTimeString()}</span>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Input Area */}
       <div className="p-4 border-t">
         <div className="flex gap-2">
           <input
@@ -108,13 +60,10 @@ const LiveChat: React.FC<LiveChatProps> = ({ onClose }) => {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && handleSend()}
-            placeholder="Type your message..."
+            placeholder={t('liveChat.placeholder')}
             className="flex-1 px-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500/20"
           />
-          <button
-            onClick={handleSend}
-            className="p-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
-          >
+          <button onClick={handleSend} className="p-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors">
             <Send className="w-5 h-5" />
           </button>
         </div>

--- a/web-client/src/components/support/SupportCenter.tsx
+++ b/web-client/src/components/support/SupportCenter.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react';
-import { Search, Book, MessageCircle, HelpCircle, Leaf, Headset, Bot, X } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Search, Book, HelpCircle, Leaf, Headset, Bot, HeadphonesIcon } from 'lucide-react';
 import HelpSearch from './HelpSearch';
 import AIGuides from './AIGuides';
 import DynamicFAQ from './DynamicFAQ';
@@ -7,19 +9,31 @@ import BlogSection from './BlogSection';
 import VRTutorials from './VRTutorials';
 import SustainabilityInfo from './SustainabilityInfo';
 import LiveChat from './LiveChat';
+import SupportClient from './SupportClient';
 
 const SupportCenter = () => {
+  const { t } = useTranslation('support');
+  const location = useLocation();
   const [activeSection, setActiveSection] = useState('search');
   const [showChat, setShowChat] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
+  const validSections = ['search', 'guides', 'faq', 'blog', 'vr', 'sustainability', 'contact'];
+
+  useEffect(() => {
+    const hash = location.hash.replace('#', '');
+    if (hash && validSections.includes(hash)) {
+      setActiveSection(hash);
+    }
+  }, [location]);
+
   const sections = [
-    { id: 'search', label: 'Help Center', icon: Search },
-    { id: 'guides', label: 'Travel Guides', icon: Book },
-    { id: 'faq', label: 'FAQ', icon: HelpCircle },
-    { id: 'blog', label: 'Blog', icon: MessageCircle },
-    { id: 'vr', label: 'VR Tutorials', icon: Headset },
-    { id: 'sustainability', label: 'Sustainability', icon: Leaf }
+    { id: 'search', label: t('navigation.helpCenter'), icon: Search },
+    { id: 'guides', label: t('navigation.guides'), icon: Book },
+    { id: 'faq', label: t('navigation.faq'), icon: HelpCircle },
+    { id: 'vr', label: t('navigation.vrTutorials'), icon: Headset },
+    { id: 'sustainability', label: t('navigation.sustainability'), icon: Leaf },
+    { id: 'contact', label: t('navigation.supportClient'), icon: HeadphonesIcon },
   ];
 
   const handleSearch = (query: string) => {
@@ -29,15 +43,14 @@ const SupportCenter = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 pt-20">
-      {/* Header */}
       <div className="bg-gradient-to-r from-orange-500 to-pink-600 text-white">
         <div className="container mx-auto px-4 py-12">
-          <h1 className="text-4xl font-bold mb-4">How can we help you?</h1>
+          <h1 className="text-4xl font-bold mb-4">{t('header.title')}</h1>
           <div className="max-w-2xl">
             <div className="relative">
               <input
                 type="text"
-                placeholder="Search for help articles..."
+                placeholder={t('header.searchPlaceholder')}
                 value={searchQuery}
                 onChange={(e) => handleSearch(e.target.value)}
                 className="w-full px-4 py-3 pl-12 bg-white/10 backdrop-blur-md rounded-lg placeholder-white/70 text-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/30"
@@ -48,7 +61,6 @@ const SupportCenter = () => {
         </div>
       </div>
 
-      {/* Navigation */}
       <div className="bg-white border-b border-gray-200 sticky top-20 z-30">
         <div className="container mx-auto px-4">
           <div className="flex overflow-x-auto no-scrollbar">
@@ -73,7 +85,6 @@ const SupportCenter = () => {
         </div>
       </div>
 
-      {/* Main Content */}
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-5xl mx-auto">
           {activeSection === 'search' && <HelpSearch initialQuery={searchQuery} />}
@@ -82,22 +93,19 @@ const SupportCenter = () => {
           {activeSection === 'blog' && <BlogSection />}
           {activeSection === 'vr' && <VRTutorials />}
           {activeSection === 'sustainability' && <SustainabilityInfo />}
+          {activeSection === 'contact' && <SupportClient />}
         </div>
       </div>
 
-      {/* Live Chat Button */}
       <button
         onClick={() => setShowChat(true)}
         className="fixed bottom-6 right-6 p-4 bg-gradient-to-r from-orange-500 to-pink-500 text-white rounded-full shadow-lg hover:opacity-90 transition-opacity flex items-center gap-2"
       >
         <Bot className="w-6 h-6" />
-        <span className="hidden md:inline">Need Help?</span>
+        <span className="hidden md:inline">{t('liveChat.button')}</span>
       </button>
 
-      {/* Live Chat Widget */}
-      {showChat && (
-        <LiveChat onClose={() => setShowChat(false)} />
-      )}
+      {showChat && <LiveChat onClose={() => setShowChat(false)} />}
     </div>
   );
 };

--- a/web-client/src/components/support/SupportClient.tsx
+++ b/web-client/src/components/support/SupportClient.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Mail, Phone, MessageCircle, Clock, CheckCircle, Send, ChevronDown } from 'lucide-react';
+
+interface Channel { title: string; desc: string; detail: string; badge: string }
+interface ResponseTime { value: string; label: string }
+
+const channelIcons = [MessageCircle, Mail, Phone];
+const channelColors = ['bg-orange-50 text-orange-500', 'bg-blue-50 text-blue-500', 'bg-purple-50 text-purple-500'];
+const badgeColors = ['bg-green-100 text-green-700', 'bg-blue-100 text-blue-700', 'bg-purple-100 text-purple-700'];
+
+export default function SupportClient() {
+  const { t } = useTranslation('support');
+  const [subject, setSubject] = useState('');
+  const [subjectOpen, setSubjectOpen] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  const channels = t('contact.channels', { returnObjects: true }) as Channel[];
+  const subjects = t('contact.subjects', { returnObjects: true }) as string[];
+  const responseTimes = t('contact.responseTimes', { returnObjects: true }) as ResponseTime[];
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSent(true);
+  };
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h2 className="text-lg font-bold text-gray-900 mb-4">{t('contact.channelsTitle')}</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {channels.map((c, i) => {
+            const Icon = channelIcons[i];
+            return (
+              <div key={i} className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                  <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${channelColors[i]}`}>
+                    <Icon className="w-5 h-5" />
+                  </div>
+                  <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${badgeColors[i]}`}>{c.badge}</span>
+                </div>
+                <div>
+                  <p className="font-semibold text-gray-900">{c.title}</p>
+                  <p className="text-sm text-gray-500 mt-0.5">{c.desc}</p>
+                </div>
+                <p className="text-xs text-gray-400 flex items-center gap-1.5">
+                  <Clock className="w-3.5 h-3.5 flex-shrink-0" />{c.detail}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 sm:p-8">
+        <h2 className="text-lg font-bold text-gray-900 mb-1">{t('contact.formTitle')}</h2>
+        <p className="text-sm text-gray-500 mb-6">{t('contact.formSubtitle')}</p>
+
+        {sent ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <div className="w-14 h-14 rounded-full bg-green-50 flex items-center justify-center">
+              <CheckCircle className="w-7 h-7 text-green-500" />
+            </div>
+            <p className="font-semibold text-gray-900">{t('contact.successTitle')}</p>
+            <p className="text-sm text-gray-500 max-w-xs">{t('contact.successText')}</p>
+            <button
+              onClick={() => { setSent(false); setForm({ name: '', email: '', message: '' }); setSubject(''); }}
+              className="mt-2 text-sm text-orange-500 hover:underline"
+            >
+              {t('contact.sendAnother')}
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('contact.nameLabel')}</label>
+                <input required type="text" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder={t('contact.namePlaceholder')}
+                  className="w-full px-4 py-2.5 rounded-xl border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-400 transition-all" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('contact.emailLabel')}</label>
+                <input required type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })}
+                  placeholder={t('contact.emailPlaceholder')}
+                  className="w-full px-4 py-2.5 rounded-xl border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-400 transition-all" />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('contact.subjectLabel')}</label>
+              <div className="relative">
+                <button type="button" onClick={() => setSubjectOpen(!subjectOpen)}
+                  className="w-full px-4 py-2.5 rounded-xl border border-gray-200 text-sm text-left flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-400 transition-all">
+                  <span className={subject ? 'text-gray-900' : 'text-gray-400'}>{subject || t('contact.subjectPlaceholder')}</span>
+                  <ChevronDown className="w-4 h-4 text-gray-400" />
+                </button>
+                {subjectOpen && (
+                  <div className="absolute z-10 mt-1 w-full bg-white border border-gray-100 rounded-xl shadow-lg overflow-hidden">
+                    {subjects.map((s) => (
+                      <button key={s} type="button" onClick={() => { setSubject(s); setSubjectOpen(false); }}
+                        className="w-full text-left px-4 py-2.5 text-sm hover:bg-orange-50 hover:text-orange-600 transition-colors">
+                        {s}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('contact.messageLabel')}</label>
+              <textarea required rows={5} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })}
+                placeholder={t('contact.messagePlaceholder')}
+                className="w-full px-4 py-2.5 rounded-xl border border-gray-200 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-400 transition-all" />
+            </div>
+
+            <button type="submit" className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-orange-500 to-pink-500 text-white text-sm font-medium rounded-xl hover:shadow-lg hover:shadow-orange-500/20 transition-all">
+              <Send className="w-4 h-4" />{t('contact.submitButton')}
+            </button>
+          </form>
+        )}
+      </div>
+
+      <div className="bg-orange-50 rounded-2xl p-5 flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between">
+        <div>
+          <p className="font-semibold text-gray-900 text-sm">{t('contact.responseTitle')}</p>
+          <p className="text-xs text-gray-500 mt-0.5">{t('contact.responseSubtitle')}</p>
+        </div>
+        <div className="flex gap-6 text-center text-sm">
+          {responseTimes.map((rt, i) => (
+            <div key={i}>
+              <p className="font-bold text-orange-600">{rt.value}</p>
+              <p className="text-xs text-gray-500">{rt.label}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/components/support/SustainabilityInfo.tsx
+++ b/web-client/src/components/support/SustainabilityInfo.tsx
@@ -1,28 +1,19 @@
-import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Leaf, Recycle, TreePine, Globe } from 'lucide-react';
 
+interface Initiative { title: string; description: string }
+interface Stat { value: string; label: string }
+
+const initiativeIcons = [TreePine, Recycle, Globe];
+
 const SustainabilityInfo = () => {
-  const initiatives = [
-    {
-      icon: TreePine,
-      title: "Carbon Offset Program",
-      description: "We partner with environmental organizations to offset the carbon footprint of your travels"
-    },
-    {
-      icon: Recycle,
-      title: "Eco-Friendly Partners",
-      description: "We work exclusively with accommodations and tour operators committed to sustainable practices"
-    },
-    {
-      icon: Globe,
-      title: "Local Community Support",
-      description: "A portion of every booking goes directly to supporting local communities"
-    }
-  ];
+  const { t } = useTranslation('support');
+  const initiatives = t('sustainability.initiatives', { returnObjects: true }) as Initiative[];
+  const stats = t('sustainability.stats', { returnObjects: true }) as Stat[];
+  const tips = t('sustainability.tips', { returnObjects: true }) as string[];
 
   return (
     <div className="space-y-8">
-      {/* Main Banner */}
       <div className="relative overflow-hidden rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 text-white">
         <div className="absolute inset-0">
           <img
@@ -34,39 +25,32 @@ const SustainabilityInfo = () => {
         <div className="relative p-8">
           <div className="flex items-center gap-3 mb-4">
             <Leaf className="w-8 h-8" />
-            <h2 className="text-2xl font-semibold">Our Commitment to Sustainability</h2>
+            <h2 className="text-2xl font-semibold">{t('sustainability.bannerTitle')}</h2>
           </div>
-          <p className="text-green-50 max-w-2xl">
-            We believe in responsible tourism that preserves destinations for future generations.
-            Learn about our initiatives to make travel more sustainable and environmentally conscious.
-          </p>
+          <p className="text-green-50 max-w-2xl">{t('sustainability.bannerText')}</p>
         </div>
       </div>
 
-      {/* Initiatives Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {initiatives.map((initiative, index) => (
-          <div key={index} className="bg-white rounded-xl shadow-sm p-6">
-            <div className="w-12 h-12 rounded-full bg-green-50 flex items-center justify-center mb-4">
-              <initiative.icon className="w-6 h-6 text-green-600" />
+        {initiatives.map((item, i) => {
+          const Icon = initiativeIcons[i];
+          return (
+            <div key={i} className="bg-white rounded-xl shadow-sm p-6">
+              <div className="w-12 h-12 rounded-full bg-green-50 flex items-center justify-center mb-4">
+                <Icon className="w-6 h-6 text-green-600" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{item.title}</h3>
+              <p className="text-gray-600">{item.description}</p>
             </div>
-            <h3 className="text-lg font-semibold mb-2">{initiative.title}</h3>
-            <p className="text-gray-600">{initiative.description}</p>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
-      {/* Impact Stats */}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h3 className="text-xl font-semibold mb-6">Our Impact</h3>
+        <h3 className="text-xl font-semibold mb-6">{t('sustainability.impactTitle')}</h3>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          {[
-            { value: "50K+", label: "Trees Planted" },
-            { value: "100K", label: "CO₂ Offset (tons)" },
-            { value: "200+", label: "Local Communities" },
-            { value: "85%", label: "Eco-Certified Partners" }
-          ].map((stat, index) => (
-            <div key={index} className="text-center">
+          {stats.map((stat, i) => (
+            <div key={i} className="text-center">
               <div className="text-2xl font-bold text-green-600 mb-1">{stat.value}</div>
               <div className="text-sm text-gray-600">{stat.label}</div>
             </div>
@@ -74,17 +58,11 @@ const SustainabilityInfo = () => {
         </div>
       </div>
 
-      {/* Eco Tips */}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h3 className="text-xl font-semibold mb-4">Sustainable Travel Tips</h3>
+        <h3 className="text-xl font-semibold mb-4">{t('sustainability.tipsTitle')}</h3>
         <div className="space-y-4">
-          {[
-            "Choose eco-friendly accommodations",
-            "Support local businesses and artisans",
-            "Use public transportation when possible",
-            "Minimize plastic waste while traveling"
-          ].map((tip, index) => (
-            <div key={index} className="flex items-start gap-3">
+          {tips.map((tip, i) => (
+            <div key={i} className="flex items-start gap-3">
               <div className="w-6 h-6 rounded-full bg-green-50 flex items-center justify-center flex-shrink-0">
                 <Leaf className="w-4 h-4 text-green-600" />
               </div>

--- a/web-client/src/components/support/VRTutorials.tsx
+++ b/web-client/src/components/support/VRTutorials.tsx
@@ -1,65 +1,45 @@
-import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Headset, Play, Book, Download } from 'lucide-react';
 
+interface VRStep { title: string; description: string }
+interface VRTutorial { title: string; duration: string; level: string; description: string }
+
+const stepIcons = [Headset, Play, Book];
+
 const VRTutorials = () => {
-  const tutorials = [
-    {
-      title: "Getting Started with VR",
-      duration: "5 min",
-      level: "Beginner",
-      description: "Learn the basics of using our VR features for immersive travel experiences",
-      image: "https://images.unsplash.com/photo-1626387346567-68d0c49ce1e5?auto=format&fit=crop&q=80"
-    },
-    {
-      title: "Advanced VR Navigation",
-      duration: "8 min",
-      level: "Intermediate",
-      description: "Master the art of navigating virtual destinations and interactive features",
-      image: "https://images.unsplash.com/photo-1622979135225-d2ba269cf1ac?auto=format&fit=crop&q=80"
-    }
-  ];
+  const { t } = useTranslation('support');
+  const steps = t('vr.steps', { returnObjects: true }) as VRStep[];
+  const tutorials = t('vr.tutorials', { returnObjects: true }) as VRTutorial[];
 
   return (
     <div className="space-y-8">
-      {/* Quick Start Guide */}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h2 className="text-xl font-semibold mb-6">Quick Start Guide</h2>
+        <h2 className="text-xl font-semibold mb-6">{t('vr.quickStartTitle')}</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {[
-            {
-              icon: Headset,
-              title: "Setup Your Device",
-              description: "Connect your VR headset or enable 360° view"
-            },
-            {
-              icon: Play,
-              title: "Launch Experience",
-              description: "Start your virtual journey with one click"
-            },
-            {
-              icon: Book,
-              title: "Follow Tutorial",
-              description: "Learn the basics with our interactive guide"
-            }
-          ].map((step, index) => (
-            <div key={index} className="p-4 bg-gray-50 rounded-lg">
-              <step.icon className="w-8 h-8 text-orange-500 mb-3" />
-              <h3 className="font-medium mb-2">{step.title}</h3>
-              <p className="text-sm text-gray-600">{step.description}</p>
-            </div>
-          ))}
+          {steps.map((step, i) => {
+            const Icon = stepIcons[i];
+            return (
+              <div key={i} className="p-4 bg-gray-50 rounded-lg">
+                <Icon className="w-8 h-8 text-orange-500 mb-3" />
+                <h3 className="font-medium mb-2">{step.title}</h3>
+                <p className="text-sm text-gray-600">{step.description}</p>
+              </div>
+            );
+          })}
         </div>
       </div>
 
-      {/* Tutorial Videos */}
       <div className="space-y-6">
-        <h2 className="text-xl font-semibold">Tutorial Videos</h2>
+        <h2 className="text-xl font-semibold">{t('vr.tutorialsTitle')}</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {tutorials.map((tutorial, index) => (
-            <div key={index} className="bg-white rounded-xl shadow-sm overflow-hidden">
+          {tutorials.map((tutorial, i) => (
+            <div key={i} className="bg-white rounded-xl shadow-sm overflow-hidden">
               <div className="aspect-video relative">
                 <img
-                  src={tutorial.image}
+                  src={[
+                    'https://images.unsplash.com/photo-1626387346567-68d0c49ce1e5?auto=format&fit=crop&q=80',
+                    'https://images.unsplash.com/photo-1622979135225-d2ba269cf1ac?auto=format&fit=crop&q=80',
+                  ][i]}
                   alt={tutorial.title}
                   className="w-full h-full object-cover"
                 />
@@ -74,10 +54,9 @@ const VRTutorials = () => {
                 </div>
                 <p className="text-sm text-gray-600 mb-4">{tutorial.description}</p>
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-orange-500">{tutorial.level}</span>
+                  <span className="text-sm text-orange-500">{t(`vr.levels.${tutorial.level}`)}</span>
                   <button className="flex items-center gap-2 text-sm text-gray-600 hover:text-orange-500 transition-colors">
-                    <Download className="w-4 h-4" />
-                    Download Resources
+                    <Download className="w-4 h-4" />{t('vr.downloadResources')}
                   </button>
                 </div>
               </div>

--- a/web-client/src/pages/blog/index.tsx
+++ b/web-client/src/pages/blog/index.tsx
@@ -1,0 +1,19 @@
+import BlogSection from '@/components/support/BlogSection';
+
+export default function BlogPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-gradient-to-br from-orange-500 to-pink-500 text-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+          <h1 className="text-3xl sm:text-4xl font-bold mb-3">Blog DreamScape</h1>
+          <p className="text-orange-100 text-lg max-w-xl mx-auto">
+            Inspirations, conseils de voyage et actualités de l'équipe DreamScape.
+          </p>
+        </div>
+      </div>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-12 max-w-5xl">
+        <BlogSection />
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/pages/help/index.tsx
+++ b/web-client/src/pages/help/index.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import {
   Rocket,
   Search,
@@ -12,7 +12,6 @@ import {
   ChevronDown,
   ChevronUp,
   Mail,
-  ExternalLink,
   MessageCircle,
 } from 'lucide-react';
 
@@ -424,6 +423,18 @@ function FaqItem({ q, a }: { q: string; a: string }) {
 
 export default function HelpPage() {
   const [activeSection, setActiveSection] = useState<string | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    const hash = location.hash;
+    if (!hash) return;
+    const guideId = hash.replace('#section-', '');
+    if (!guides.some((g) => g.id === guideId)) return;
+    setActiveSection(guideId);
+    setTimeout(() => {
+      document.getElementById(`section-${guideId}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 150);
+  }, [location]);
 
   const handleGuideClick = (id: string) => {
     const next = id === activeSection ? null : id;
@@ -502,7 +513,7 @@ export default function HelpPage() {
         </section>
 
         {/* FAQ */}
-        <section className="mb-14">
+        <section id="faq" className="mb-14">
           <h2 className="text-xl font-bold text-gray-900 mb-6">Questions fréquentes</h2>
           <div className="space-y-3">
             {faqs.map((faq) => (

--- a/web-client/src/pages/support/index.tsx
+++ b/web-client/src/pages/support/index.tsx
@@ -1,28 +1,5 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
 import SupportCenter from '@/components/support/SupportCenter';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
 
 export default function SupportPage() {
-  const { t } = useTranslation('support');
-  const navigate = useNavigate();
-
-  return (
-    <main className="min-h-screen bg-gray-50 pt-20">
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center gap-4 mb-6">
-          <button
-            onClick={() => navigate(-1)}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-            aria-label={t('page.ariaLabel.goBack')}
-          >
-            <ArrowLeft className="w-5 h-5" />
-          </button>
-          <h1 className="text-2xl font-bold">{t('page.title')}</h1>
-        </div>
-        <SupportCenter />
-      </div>
-    </main>
-  );
+  return <SupportCenter />;
 }


### PR DESCRIPTION
- Replace all placeholder # hrefs with real routes and hash anchors
- Footer resources: guide → /help#section-*, faq → /faq, support → /support, blog → /blog
- Footer destinations: all links → /destinations
- Bottom bar: privacy/terms/cookies → /help#section-rgpd
- LinkedIn only (removed Instagram, Twitter, Facebook, YouTube)
- Copyright year dynamic via {{year}} i18n interpolation
- Translate all support/* components with useTranslation('support')
- Add SupportClient tab (contact form + channels) in SupportCenter
- Add /blog page (extracted from SupportCenter Blog tab)
- HelpPage: useEffect on location to open & scroll to hash section
- SupportCenter: useEffect on location to activate tab from hash