### PR TITLE
fix(navigation): scroll to top on route change

### DIFF
--- a/web-client/src/components/shared/ScrollToTop.tsx
+++ b/web-client/src/components/shared/ScrollToTop.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    document.querySelectorAll<HTMLElement>('main').forEach((el) => {
+      el.scrollTop = 0;
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/web-client/src/layouts/AdminLayout.tsx
+++ b/web-client/src/layouts/AdminLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { useAuth } from '@/services/auth/AuthService';
+import ScrollToTop from '@/components/shared/ScrollToTop';
 
 const NAV_ITEMS = [
   { label: 'Dashboard', path: '/admin/dashboard', icon: '📊' },
@@ -20,6 +21,7 @@ const AdminLayout = () => {
 
   return (
     <div className="min-h-screen flex bg-gray-50">
+      <ScrollToTop />
       {/* Sidebar */}
       <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
         <div className="p-6 border-b border-gray-200">

--- a/web-client/src/layouts/RootLayout.tsx
+++ b/web-client/src/layouts/RootLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { CartDrawer } from '@/components/cart';
+import ScrollToTop from '@/components/shared/ScrollToTop';
 import { useAuth } from '@/services/auth/AuthService';
 import { useLanguageSync } from '@/i18n/useLanguageSync';
 
@@ -29,6 +30,7 @@ export default function RootLayout() {
 
   return (
     <div className="min-h-screen flex flex-col">
+      <ScrollToTop />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-orange-500 focus:text-white focus:rounded-lg focus:font-medium"


### PR DESCRIPTION
## Summary
- Pages kept the previous scroll position on navigation, forcing users to manually scroll back to the top.
- Added a `ScrollToTop` component that resets `window` scroll and any `<main>` with `overflow-auto` on every `pathname` change.
- Mounted it in both `RootLayout` (public pages) and `AdminLayout` (admin area has its own scroll container).

## Test plan
- [ ] Navigate between public pages (home → destinations → destination detail) and confirm each page opens at the top.
- [ ] Scroll down a long page, click a link in the header/footer, confirm the new page starts at the top.
- [ ] In the admin area, scroll the main content, navigate between admin sections, confirm the main panel is reset to the top.
- [ ] Back/forward browser buttons still behave sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)